### PR TITLE
Proposed modification on line 205 of README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,7 +202,7 @@ such:
 
     # Once it learned, the pipeline can process new and
     # unseen data for making predictions.
-    y_train_predicted = p.transform(X_train)
+    y_test_predicted = p.transform(X_test)
 
 Visit the
 `examples <https://www.neuraxle.neuraxio.com/stable/examples/index.html>`__


### PR DESCRIPTION
Unseen data refer to X_test & y_test_predicted, not X_train & y_train_predicted