### PR TITLE
Refactor Pipeline To Seamlessly Use A Data Container Object

### DIFF
--- a/neuraxle/steps/sklearn.py
+++ b/neuraxle/steps/sklearn.py
@@ -23,7 +23,7 @@ Those steps works with scikit-learn (sklearn) transformers and estimators.
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import Ridge
 
-from neuraxle.base import BaseStep
+from neuraxle.base import BaseStep, IDHasher, Hasher
 from neuraxle.hyperparams.distributions import LogUniform, Boolean
 from neuraxle.hyperparams.space import HyperparameterSpace, HyperparameterSamples
 from neuraxle.steps.numpy import NumpyTranspose
@@ -35,13 +35,14 @@ class SKLearnWrapper(BaseStep):
             self,
             wrapped_sklearn_predictor,
             hyperparams_space: HyperparameterSpace = None,
-            return_all_sklearn_default_params_on_get=False
+            return_all_sklearn_default_params_on_get=False,
+            hasher: Hasher = IDHasher()
     ):
         if not isinstance(wrapped_sklearn_predictor, BaseEstimator):
             raise ValueError("The wrapped_sklearn_predictor must be an instance of scikit-learn's BaseEstimator.")
         self.wrapped_sklearn_predictor = wrapped_sklearn_predictor
         params: HyperparameterSamples = wrapped_sklearn_predictor.get_params()
-        super().__init__(params, hyperparams_space)
+        super().__init__(hyperparams=params, hyperparams_space=hyperparams_space, hasher=hasher)
         self.return_all_sklearn_default_params_on_get = return_all_sklearn_default_params_on_get
 
     def fit(self, data_inputs, expected_outputs=None) -> 'SKLearnWrapper':

--- a/testing/test_pipeline.py
+++ b/testing/test_pipeline.py
@@ -22,7 +22,7 @@ Tests for Pipelines
 import numpy as np
 import pytest
 
-from neuraxle.base import BaseStep
+from neuraxle.base import BaseStep, HasherByIndex
 from neuraxle.hyperparams.distributions import RandInt, LogUniform
 from neuraxle.hyperparams.space import nested_dict_to_flat, HyperparameterSpace
 from neuraxle.pipeline import Pipeline
@@ -36,9 +36,8 @@ AN_EXPECTED_OUTPUT = "I am an expected output"
 
 
 class SomeStep(BaseStep):
-
-    def __init__(self, hyperparams_space: HyperparameterSpace = None):
-        super().__init__(None, hyperparams_space)
+    def __init__(self, hyperparams_space: HyperparameterSpace = None, hasher=HasherByIndex()):
+        super().__init__(hyperparams=None, hyperparams_space=hyperparams_space, hasher=hasher)
 
     def fit_one(self, data_input, expected_output=None) -> 'SomeStep':
         return self


### PR DESCRIPTION
1. Introduce **handle_transform** and **handle_fit_transform** method inside BaseStep to execute side effects on the new **DataContainer** Object after fits and transforms. 

2. Introduce **DataContainer** Object to keep track of : 

- original_ids
- ids
- data inputs
- expected outputs 

This will enable ids and hyperparams hashing.

**The hyperparams/ids checkpointing itself will be done in the next pr.** 