### PR TITLE
Pipeline Id And Hyperparameters Blockchain Rehashing For Checkpointing

### DIFF
--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -426,15 +426,13 @@ class MetaStepMixin:
         name__ = MetaStepMixin.__name__
 
         self.wrapped.setup(
-            step_path=os.path.join(step_path, '{0}({1})'.format(self.wrapped.name, name__)),
+            step_path=os.path.join(step_path, self.name),
             setup_arguments=setup_arguments
         )
 
-        return self
+        self.is_initialized = True
 
-    @abstractmethod
-    def get_name(self):
-        return '{0}({1})'.format(self.wrapped.name,  MetaStepMixin.__name__)
+        return self
 
     def set_hyperparams(self, hyperparams: HyperparameterSamples) -> BaseStep:
         self.wrapped = self.wrapped.set_hyperparams(hyperparams)

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -126,9 +126,9 @@ class BaseStep(ABC):
     def setup(self, step_path: str, setup_arguments: dict) -> 'BaseStep':
         """
         Initialize step before it runs
+
         :param step_path: pipeline step path ex: pipeline/step_name/
-        :param setup_arguments: any setup arguments
-        that need to be passed to the setup method of one of the pipeline step
+        :param setup_arguments: any setup arguments that need to be passed to the setup method of one of the pipeline step
         :return: self
         """
         self.is_initialized = True
@@ -137,6 +137,7 @@ class BaseStep(ABC):
     def teardown(self):
         """
         Teardown step after program execution
+
         :return:
         """
         self.is_initialized = False
@@ -181,7 +182,8 @@ class BaseStep(ABC):
     def handle_fit_transform(self, data_container: DataContainer) -> ('BaseStep', Any):
         """
         Update the data inputs inside DataContainer after fit transform,
-         and update its current_ids.
+        and update its current_ids.
+
         :param data_container: the data container to transform
         :return: tuple(fitted pipeline, data_container)
         """
@@ -196,6 +198,7 @@ class BaseStep(ABC):
     def handle_transform(self, data_container: DataContainer) -> Any:
         """
         Update the data inputs inside DataContainer after transform.
+
         :param data_container: the data container to transform
         :return: transformed data container
         """

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -117,8 +117,12 @@ class BaseStep(ABC):
 
         self.name: str = name
         self.hasher = hasher
+
         self.hyperparams: HyperparameterSamples = HyperparameterSamples(hyperparams)
+        self.hyperparams = self.hyperparams.to_flat()
+
         self.hyperparams_space: HyperparameterSpace = HyperparameterSpace(hyperparams_space)
+        self.hyperparams_space = self.hyperparams_space.to_flat()
 
         self.pending_mutate: ('BaseStep', str, str) = (None, None, None)
         self.is_initialized = False
@@ -162,14 +166,14 @@ class BaseStep(ABC):
         return self.name
 
     def set_hyperparams(self, hyperparams: HyperparameterSamples) -> 'BaseStep':
-        self.hyperparams = HyperparameterSamples(hyperparams)
+        self.hyperparams = HyperparameterSamples(hyperparams).to_flat()
         return self
 
     def get_hyperparams(self) -> HyperparameterSamples:
         return self.hyperparams
 
     def set_hyperparams_space(self, hyperparams_space: HyperparameterSpace) -> 'BaseStep':
-        self.hyperparams_space = HyperparameterSpace(hyperparams_space)
+        self.hyperparams_space = HyperparameterSpace(hyperparams_space).to_flat()
         return self
 
     def set_hasher(self, hasher: BaseHasher) -> 'BaseStep':
@@ -435,14 +439,14 @@ class MetaStepMixin:
         return self
 
     def set_hyperparams(self, hyperparams: HyperparameterSamples) -> BaseStep:
-        self.wrapped = self.wrapped.set_hyperparams(hyperparams)
+        self.wrapped = self.wrapped.set_hyperparams(hyperparams.to_flat())
         return self
 
     def get_hyperparams(self) -> HyperparameterSamples:
         return self.wrapped.get_hyperparams()
 
     def set_hyperparams_space(self, hyperparams_space: HyperparameterSpace) -> 'BaseStep':
-        self.wrapped = self.wrapped.set_hyperparams_space(hyperparams_space)
+        self.wrapped = self.wrapped.set_hyperparams_space(hyperparams_space.to_flat())
         return self
 
     def get_hyperparams_space(self) -> HyperparameterSpace:
@@ -610,7 +614,7 @@ class TruncableSteps(BaseStep, ABC):
 
         hyperparams = HyperparameterSamples(hyperparams)
 
-        return hyperparams.to_flat()
+        return hyperparams
 
     def set_hyperparams(self, hyperparams: Union[HyperparameterSamples, OrderedDict, dict]) -> BaseStep:
         hyperparams: HyperparameterSamples = HyperparameterSamples(hyperparams).to_nested_dict()
@@ -649,7 +653,7 @@ class TruncableSteps(BaseStep, ABC):
             super().get_hyperparams_space()
         )
 
-        return all_hyperparams.to_flat()
+        return all_hyperparams
 
     def mutate(self, new_method="inverse_transform", method_to_assign_to="transform", warn=True) -> 'BaseStep':
         """

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -614,7 +614,7 @@ class TruncableSteps(BaseStep, ABC):
 
         hyperparams = HyperparameterSamples(hyperparams)
 
-        return hyperparams
+        return hyperparams.to_flat()
 
     def set_hyperparams(self, hyperparams: Union[HyperparameterSamples, OrderedDict, dict]) -> BaseStep:
         hyperparams: HyperparameterSamples = HyperparameterSamples(hyperparams).to_nested_dict()
@@ -653,7 +653,7 @@ class TruncableSteps(BaseStep, ABC):
             super().get_hyperparams_space()
         )
 
-        return all_hyperparams
+        return all_hyperparams.to_flat()
 
     def mutate(self, new_method="inverse_transform", method_to_assign_to="transform", warn=True) -> 'BaseStep':
         """

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -51,6 +51,19 @@ class IDHasher(Hasher):
         return ids
 
 
+class HasherByHyperparameters(Hasher):
+    def rehash(self,
+               ids, hyperparameters: HyperparameterSamples,
+               data_inputs: Any
+               ):
+        current_hyperparameters_hash = hash(frozenset(hyperparameters.to_flat()))
+
+        return [
+            hash((data_input_id, current_hyperparameters_hash))
+            for data_input_id in ids
+        ]
+
+
 class DataContainer:
     def __init__(self, ids, data_inputs: Any, expected_outputs: Any = None):
         self.original_ids = ids

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -179,7 +179,7 @@ class BaseStep(ABC):
     def get_hyperparams_space(self) -> HyperparameterSpace:
         return self.hyperparams_space
 
-    def handle_fit_transform(self, data_container: DataContainer) -> ('BaseStep', Any):
+    def handle_fit_transform(self, data_container: DataContainer) -> ('BaseStep', DataContainer):
         """
         Update the data inputs inside DataContainer after fit transform,
         and update its current_ids.
@@ -195,7 +195,7 @@ class BaseStep(ABC):
 
         return new_self, data_container
 
-    def handle_transform(self, data_container: DataContainer) -> Any:
+    def handle_transform(self, data_container: DataContainer) -> DataContainer:
         """
         Update the data inputs inside DataContainer after transform.
 
@@ -798,5 +798,5 @@ class ResumableStepMixin:
     """
 
     @abstractmethod
-    def should_resume(self, data_container) -> bool:
+    def should_resume(self, data_container: DataContainer) -> bool:
         raise NotImplementedError()

--- a/neuraxle/checkpoints.py
+++ b/neuraxle/checkpoints.py
@@ -17,7 +17,6 @@ The checkpoint classes used by the checkpoint pipeline runner
 import os
 import pickle
 from abc import abstractmethod
-from typing import Any
 
 from neuraxle.base import ResumableStepMixin, BaseStep, DataContainer
 
@@ -38,10 +37,10 @@ class BaseCheckpointStep(ResumableStepMixin, BaseStep):
     def setup(self, step_path: str, setup_arguments: dict):
         self.set_checkpoint_path(step_path)
 
-    def handle_transform(self, data_container: DataContainer) -> Any:
+    def handle_transform(self, data_container: DataContainer) -> DataContainer:
         return self.save_checkpoint(data_container)
 
-    def handle_fit_transform(self, data_container: DataContainer) -> ('BaseStep', Any):
+    def handle_fit_transform(self, data_container: DataContainer) -> ('BaseStep', DataContainer):
         return self, self.save_checkpoint(data_container)
 
     def fit(self, data_inputs, expected_outputs=None) -> 'BaseCheckpointStep':
@@ -106,7 +105,7 @@ class PickleCheckpointStep(BaseCheckpointStep):
         super().__init__()
         self.cache_folder = cache_folder
 
-    def read_checkpoint(self, data_container: DataContainer):
+    def read_checkpoint(self, data_container: DataContainer) -> DataContainer:
         """
         Read pickle files for data inputs and expected outputs checkpoint
 
@@ -130,7 +129,7 @@ class PickleCheckpointStep(BaseCheckpointStep):
 
         return checkpoint_data_container
 
-    def save_checkpoint(self, data_container: DataContainer):
+    def save_checkpoint(self, data_container: DataContainer) -> DataContainer:
         """
         Save pickle files for data inputs and expected output to create a checkpoint
 
@@ -177,7 +176,7 @@ class PickleCheckpointStep(BaseCheckpointStep):
 
         return True
 
-    def get_checkpoint_file_path(self, current_id):
+    def get_checkpoint_file_path(self, current_id) -> str:
         """
         Returns the checkpoint file path for a data input id
 

--- a/neuraxle/checkpoints.py
+++ b/neuraxle/checkpoints.py
@@ -48,6 +48,7 @@ class BaseCheckpointStep(ResumableStepMixin, BaseStep):
         """
         Save checkpoint for data inputs and expected outputs so that it can
         be loaded by the checkpoint pipeline runner on the next pipeline run
+
         :param expected_outputs: initial expected outputs of pipeline to load checkpoint from
         :param data_inputs: data inputs to save
         :return: self
@@ -58,6 +59,7 @@ class BaseCheckpointStep(ResumableStepMixin, BaseStep):
         """
         Save checkpoint for data inputs and expected outputs so that it can
         be loaded by the checkpoint pipeline runner on the next pipeline run
+
         :param data_inputs: data inputs to save
         :return: data_inputs
         """
@@ -67,6 +69,7 @@ class BaseCheckpointStep(ResumableStepMixin, BaseStep):
     def set_checkpoint_path(self, path):
         """
         Set checkpoint Path
+
         :param path: checkpoint path
         """
         raise NotImplementedError()
@@ -75,6 +78,7 @@ class BaseCheckpointStep(ResumableStepMixin, BaseStep):
     def read_checkpoint(self, data_container: DataContainer) -> DataContainer:
         """
         Read checkpoint data to get the data inputs and expected output.
+
         :param data_container: data inputs to save
         :return: checkpoint data container
         """
@@ -85,6 +89,7 @@ class BaseCheckpointStep(ResumableStepMixin, BaseStep):
         """
         Save checkpoint for data inputs and expected outputs so that it can
         be loaded by the checkpoint pipeline runner on the next pipeline run
+
         :param data_container: data inputs to save
         :return: saved data container
         """
@@ -104,6 +109,7 @@ class PickleCheckpointStep(BaseCheckpointStep):
     def read_checkpoint(self, data_container: DataContainer):
         """
         Read pickle files for data inputs and expected outputs checkpoint
+
         :return: tuple(data_inputs, expected_outputs
         """
         checkpoint_data_container = DataContainer(
@@ -126,8 +132,8 @@ class PickleCheckpointStep(BaseCheckpointStep):
 
     def save_checkpoint(self, data_container: DataContainer):
         """
-        Save pickle files for data inputs and expected output
-        to create a checkpoint
+        Save pickle files for data inputs and expected output to create a checkpoint
+
         :param data_container: data to resume
         :return:
         """
@@ -143,6 +149,7 @@ class PickleCheckpointStep(BaseCheckpointStep):
     def set_checkpoint_path(self, path):
         """
         Set checkpoint path inside the cache folder (ex: cache_folder/pipeline/step_a/current_id.pickle)
+
         :param path: checkpoint path
         """
         self.checkpoint_path = os.path.join(self.cache_folder, path)
@@ -152,6 +159,7 @@ class PickleCheckpointStep(BaseCheckpointStep):
     def should_resume(self, data_container: DataContainer) -> bool:
         """
         Whether or not we should resume the pipeline (if the checkpoint exists)
+
         :param data_container: data to resume
         :return:
         """
@@ -172,6 +180,7 @@ class PickleCheckpointStep(BaseCheckpointStep):
     def get_checkpoint_file_path(self, current_id):
         """
         Returns the checkpoint file path for a data input id
+
         :param current_id:
         :return:
         """

--- a/neuraxle/checkpoints.py
+++ b/neuraxle/checkpoints.py
@@ -35,6 +35,9 @@ class BaseCheckpointStep(ResumableStepMixin, BaseStep):
         BaseStep.__init__(self)
         self.force_checkpoint_name = force_checkpoint_name
 
+    def setup(self, step_path: str, setup_arguments: dict):
+        self.set_checkpoint_path(step_path)
+
     def handle_transform(self, data_container: DataContainer) -> Any:
         self.save_checkpoint(data_container)
         return data_container
@@ -84,7 +87,6 @@ class BaseCheckpointStep(ResumableStepMixin, BaseStep):
         """
         Save checkpoint for data inputs and expected outputs so that it can
         be loaded by the checkpoint pipeline runner on the next pipeline run
-        :param ids: data inputs ids
         :param data_container: data inputs to save
         :return:
         """
@@ -97,20 +99,36 @@ class PickleCheckpointStep(BaseCheckpointStep):
     to eventually be able to load them using the checkpoint pipeline runner.
     """
 
-    def __init__(self, force_checkpoint_name: str = None, cache_folder: str = DEFAULT_CACHE_FOLDER):
-        super().__init__(force_checkpoint_name)
+    def __init__(self, cache_folder: str = DEFAULT_CACHE_FOLDER):
+        super().__init__()
         self.cache_folder = cache_folder
-        self.force_checkpoint_name = force_checkpoint_name
 
     def read_checkpoint(self, data_container: DataContainer):
         """
         Read pickle files for data inputs and expected outputs checkpoint
         :return: tuple(data_inputs, expected_outputs
         """
-        with open(self.get_checkpoint_file_path(data_container), 'rb') as file:
-            checkpoint = pickle.load(file)
+        checkpoint_data_container = DataContainer(
+            current_ids=[],
+            data_inputs=[],
+            expected_outputs=None
+        )
 
-        return checkpoint
+        for current_id, data_input, expected_output in zip(
+                data_container.current_ids,
+                data_container.data_inputs,
+                data_container.expected_outputs
+        ):
+            with open(self.get_checkpoint_file_path(current_id), 'wb') as file:
+                (checkpoint_current_id, checkpoint_data_input, checkpoint_expected_output) = \
+                    pickle.load(file)
+                checkpoint_data_container.append(
+                    current_id=checkpoint_current_id,
+                    data_input=checkpoint_data_input,
+                    expected_output=checkpoint_expected_output
+                )
+
+        return checkpoint_data_container
 
     def save_checkpoint(self, data_container: DataContainer):
         """
@@ -119,18 +137,22 @@ class PickleCheckpointStep(BaseCheckpointStep):
         :param data_container: data inputs to be saved in a pickle file
         :return:
         """
-        self.set_checkpoint_path(self.force_checkpoint_name)
-        with open(self.get_checkpoint_file_path(data_container), 'wb') as file:
-            pickle.dump(data_container, file)
+        for current_id, data_input, expected_output in zip(
+                data_container.current_ids,
+                data_container.data_inputs,
+                data_container.expected_outputs
+        ):
+            with open(self.get_checkpoint_file_path(current_id), 'wb') as file:
+                pickle.dump(
+                    (current_id, data_input, expected_output),
+                    file
+                )
 
     def set_checkpoint_path(self, path):
         """
-        Set checkpoint path inside the cache folder (ex: cache_folder/pipeline_name/force_checkpoint_name/data_inputs.pickle)
+        Set checkpoint path inside the cache folder (ex: cache_folder/pipeline/step_a/id_rehashed.pickle)
         :param path: checkpoint path
         """
-        if path is None:
-            path = self.name
-
         self.checkpoint_path = os.path.join(self.cache_folder, path)
         if not os.path.exists(self.checkpoint_path):
             os.makedirs(self.checkpoint_path)
@@ -139,8 +161,14 @@ class PickleCheckpointStep(BaseCheckpointStep):
         return self.checkpoint_exists(data_container)
 
     def checkpoint_exists(self, data_container: DataContainer) -> bool:
-        self.set_checkpoint_path(self.force_checkpoint_name)
-        return os.path.exists(self.get_checkpoint_file_path(data_container))
+        for current_id in data_container.current_ids:
+            if not os.path.exists(self.get_checkpoint_file_path(current_id)):
+                return False
 
-    def get_checkpoint_file_path(self, data_container: DataContainer):
-        return os.path.join(self.checkpoint_path, 'data_inputs.pickle')
+        return True
+
+    def get_checkpoint_file_path(self, current_id):
+        return os.path.join(
+            self.checkpoint_path,
+            '{0}.pickle'.format(current_id)
+        )

--- a/neuraxle/pipeline.py
+++ b/neuraxle/pipeline.py
@@ -147,7 +147,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
             processed_outputs = step.transform(processed_outputs)
         return processed_outputs
 
-    def handle_fit_transform(self, data_container: DataContainer) -> ('BaseStep', Any):
+    def handle_fit_transform(self, data_container: DataContainer) -> ('BaseStep', DataContainer):
         """
         Fit transform then rehash ids with hyperparams and transformed data inputs
 
@@ -161,7 +161,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
 
         return new_self, data_container
 
-    def handle_transform(self, data_container: DataContainer) -> Any:
+    def handle_transform(self, data_container: DataContainer) -> DataContainer:
         """
         Transform then rehash ids with hyperparams and transformed data inputs
 
@@ -195,7 +195,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
 
         return self, data_container
 
-    def _transform_core(self, data_container: DataContainer):
+    def _transform_core(self, data_container: DataContainer) -> DataContainer:
         """
         After loading the last checkpoint, transform each pipeline steps
 

--- a/neuraxle/pipeline.py
+++ b/neuraxle/pipeline.py
@@ -66,6 +66,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def transform(self, data_inputs: Any):
         """
         After loading the last checkpoint, transform each pipeline steps
+
         :param data_inputs: the data input to transform
         :return: transformed data inputs
         """
@@ -86,6 +87,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def fit_transform(self, data_inputs, expected_outputs=None) -> ('Pipeline', Any):
         """
         After loading the last checkpoint, fit transform each pipeline steps
+
         :param data_inputs: the data input to fit on
         :param expected_outputs: the expected data output to fit on
         :return: the pipeline itself
@@ -111,6 +113,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def fit(self, data_inputs, expected_outputs=None) -> 'Pipeline':
         """
         After loading the last checkpoint, fit each pipeline steps
+
         :param data_inputs: the data input to fit on
         :param expected_outputs: the expected data output to fit on
         :return: the pipeline itself
@@ -136,6 +139,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def inverse_transform_processed_outputs(self, processed_outputs) -> Any:
         """
         After transforming all data inputs, and obtaining a prediction, we can inverse transform the processed outputs
+
         :param processed_outputs: the forward transformed data input
         :return: backward transformed processed outputs
         """
@@ -146,6 +150,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def handle_fit_transform(self, data_container: DataContainer) -> ('BaseStep', Any):
         """
         Fit transform then rehash ids with hyperparams and transformed data inputs
+
         :param data_container: data container to fit transform
         :return: tuple(fitted pipeline, transformed data container)
         """
@@ -159,6 +164,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def handle_transform(self, data_container: DataContainer) -> Any:
         """
         Transform then rehash ids with hyperparams and transformed data inputs
+
         :param data_container: data container to transform
         :return: tuple(fitted pipeline, transformed data container)
         """
@@ -172,6 +178,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def _fit_transform_core(self, data_container) -> ('Pipeline', DataContainer):
         """
         After loading the last checkpoint, fit transform each pipeline steps
+
         :param data_container: the data container to fit transform on
         :return: tuple(pipeline, data_container)
         """
@@ -191,6 +198,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def _transform_core(self, data_container: DataContainer):
         """
         After loading the last checkpoint, transform each pipeline steps
+
         :param data_container: the data container to transform
         :return: transformed data container
         """
@@ -204,6 +212,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def _load_pipeline_checkpoint(self, data_container: DataContainer) -> Tuple[NamedTupleList, DataContainer]:
         """
         Find the steps left to do, and load the latest checkpoint step data container
+
         :param data_container: the data container to resume
         :return: tuple(steps left to do, last checkpoint data container)
         """
@@ -218,6 +227,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def _find_starting_step_index(self, data_container: DataContainer) -> int:
         """
         Find the index of the latest step that can be resumed
+
         :param data_container: the data container to resume
         :return: int index latest resumable step
         """
@@ -242,6 +252,7 @@ class Pipeline(BasePipeline, ResumableStepMixin):
     def should_resume(self, data_container: DataContainer) -> bool:
         """
         Return True if the pipeline has a saved checkpoint that it can resume from
+
         :param data_container: the data container to resume
         :return: bool
         """

--- a/neuraxle/steps/sklearn.py
+++ b/neuraxle/steps/sklearn.py
@@ -23,7 +23,7 @@ Those steps works with scikit-learn (sklearn) transformers and estimators.
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import Ridge
 
-from neuraxle.base import BaseStep, IDHasher, Hasher
+from neuraxle.base import BaseStep
 from neuraxle.hyperparams.distributions import LogUniform, Boolean
 from neuraxle.hyperparams.space import HyperparameterSpace, HyperparameterSamples
 from neuraxle.steps.numpy import NumpyTranspose
@@ -35,14 +35,13 @@ class SKLearnWrapper(BaseStep):
             self,
             wrapped_sklearn_predictor,
             hyperparams_space: HyperparameterSpace = None,
-            return_all_sklearn_default_params_on_get=False,
-            hasher: Hasher = IDHasher()
+            return_all_sklearn_default_params_on_get=False
     ):
         if not isinstance(wrapped_sklearn_predictor, BaseEstimator):
             raise ValueError("The wrapped_sklearn_predictor must be an instance of scikit-learn's BaseEstimator.")
         self.wrapped_sklearn_predictor = wrapped_sklearn_predictor
         params: HyperparameterSamples = wrapped_sklearn_predictor.get_params()
-        super().__init__(hyperparams=params, hyperparams_space=hyperparams_space, hasher=hasher)
+        super().__init__(hyperparams=params, hyperparams_space=hyperparams_space)
         self.return_all_sklearn_default_params_on_get = return_all_sklearn_default_params_on_get
 
     def fit(self, data_inputs, expected_outputs=None) -> 'SKLearnWrapper':

--- a/neuraxle/steps/sklearn.py
+++ b/neuraxle/steps/sklearn.py
@@ -23,7 +23,7 @@ Those steps works with scikit-learn (sklearn) transformers and estimators.
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import Ridge
 
-from neuraxle.base import BaseStep
+from neuraxle.base import BaseStep, IDHasher, Hasher
 from neuraxle.hyperparams.distributions import LogUniform, Boolean
 from neuraxle.hyperparams.space import HyperparameterSpace, HyperparameterSamples
 from neuraxle.steps.numpy import NumpyTranspose
@@ -35,13 +35,14 @@ class SKLearnWrapper(BaseStep):
             self,
             wrapped_sklearn_predictor,
             hyperparams_space: HyperparameterSpace = None,
-            return_all_sklearn_default_params_on_get=False
+            return_all_sklearn_default_params_on_get=False,
+            hasher: Hasher = IDHasher()
     ):
         if not isinstance(wrapped_sklearn_predictor, BaseEstimator):
             raise ValueError("The wrapped_sklearn_predictor must be an instance of scikit-learn's BaseEstimator.")
         self.wrapped_sklearn_predictor = wrapped_sklearn_predictor
         params: HyperparameterSamples = wrapped_sklearn_predictor.get_params()
-        super().__init__(params, hyperparams_space)
+        super().__init__(hyperparams=params, hyperparams_space=hyperparams_space, hasher=hasher)
         self.return_all_sklearn_default_params_on_get = return_all_sklearn_default_params_on_get
 
     def fit(self, data_inputs, expected_outputs=None) -> 'SKLearnWrapper':

--- a/neuraxle/steps/util.py
+++ b/neuraxle/steps/util.py
@@ -30,14 +30,14 @@ from neuraxle.base import BaseStep, NonFittableMixin, NonTransformableMixin, Met
 class BaseCallbackStep(BaseStep, ABC):
     """Base class for callback steps."""
 
-    def __init__(self, callback_function, more_arguments: List = tuple()):
+    def __init__(self, callback_function, more_arguments: List = tuple(), hyperparams = None):
         """
         Create the callback step with a function and extra arguments to send to the function
 
         :param callback_function: The function that will be called on events.
         :param more_arguments: Extra arguments that will be sent to the callback after the processed data (optional).
         """
-        super().__init__()
+        super().__init__(hyperparams=hyperparams)
         self.callback_function = callback_function
         self.more_arguments = more_arguments
 

--- a/testing/test_pickle_checkpoint_step.py
+++ b/testing/test_pickle_checkpoint_step.py
@@ -16,23 +16,11 @@ expected_outputs = np.array([2, 3])
 expected_rehashed_data_inputs = ['44f9d6dd8b6ccae571ca04525c3eaffa', '898a67b2f5eeae6393ca4b3162ba8e3d']
 
 
-def create_pipeline_without_hyperparams(pickle_checkpoint_step, tape):
-    pipeline = Pipeline(
-        steps=[
-            ('a', TransformCallbackStep(tape.callback, ["1"])),
-            ('pickle_checkpoint', pickle_checkpoint_step),
-            ('c', TransformCallbackStep(tape.callback, ["2"])),
-            ('d', TransformCallbackStep(tape.callback, ["3"]))
-        ]
-    )
-    return pipeline
-
-
-def create_pipeline_with_hyperparams(pickle_checkpoint_step, tape):
+def create_pipeline(pickle_checkpoint_step, tape, hyperparameters = None):
     pipeline = Pipeline(
         steps=[
             ('a',
-             TransformCallbackStep(tape.callback, ["1"], hyperparams=HyperparameterSamples({"a__learning_rate": 1}))),
+             TransformCallbackStep(tape.callback, ["1"], hyperparams=hyperparameters)),
             ('pickle_checkpoint', pickle_checkpoint_step),
             ('c', TransformCallbackStep(tape.callback, ["2"])),
             ('d', TransformCallbackStep(tape.callback, ["3"]))
@@ -44,7 +32,7 @@ def create_pipeline_with_hyperparams(pickle_checkpoint_step, tape):
 def test_when_no_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
     tape = TapeCallbackFunction()
     pickle_checkpoint_step = create_pickle_checkpoint_step(tmpdir)
-    pipeline = create_pipeline_without_hyperparams(pickle_checkpoint_step, tape)
+    pipeline = create_pipeline(pickle_checkpoint_step, tape)
 
     pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
 
@@ -58,7 +46,7 @@ def test_when_no_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
 def test_when_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
     tape = TapeCallbackFunction()
     pickle_checkpoint_step = create_pickle_checkpoint_step(tmpdir)
-    pipeline = create_pipeline_with_hyperparams(pickle_checkpoint_step, tape)
+    pipeline = create_pipeline(pickle_checkpoint_step, tape, HyperparameterSamples({"a__learning_rate": 1}))
 
     pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
 
@@ -84,7 +72,7 @@ def test_when_no_hyperparams_should_load_checkpoint_pickle(tmpdir: LocalPath):
         expected_output=expected_outputs[1],
         pickle_checkpoint_step=pickle_checkpoint_step
     )
-    pipeline = create_pipeline_without_hyperparams(pickle_checkpoint_step, tape)
+    pipeline = create_pipeline(pickle_checkpoint_step, tape)
 
     pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
 
@@ -109,7 +97,7 @@ def test_when_hyperparams_should_load_checkpoint_pickle(tmpdir: LocalPath):
         pickle_checkpoint_step=pickle_checkpoint_step
     )
 
-    pipeline = create_pipeline_with_hyperparams(pickle_checkpoint_step, tape)
+    pipeline = create_pipeline(pickle_checkpoint_step, tape, HyperparameterSamples({"a__learning_rate": 1}))
 
     pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
 

--- a/testing/test_pickle_checkpoint_step.py
+++ b/testing/test_pickle_checkpoint_step.py
@@ -5,55 +5,125 @@ import numpy as np
 from py._path.local import LocalPath
 
 from neuraxle.checkpoints import PickleCheckpointStep
+from neuraxle.hyperparams.space import HyperparameterSamples
 from neuraxle.pipeline import Pipeline
 from neuraxle.steps.util import TapeCallbackFunction, TransformCallbackStep
 
-data_inputs = np.ones((1, 1))
-expected_outputs = np.ones((2, 2))
+EXPECTED_TAPE_AFTER_CHECKPOINT = ["2", "3"]
+
+data_inputs = np.array([1, 2])
+expected_outputs = np.array([2, 3])
+expected_rehashed_data_inputs = ['44f9d6dd8b6ccae571ca04525c3eaffa', '898a67b2f5eeae6393ca4b3162ba8e3d']
 
 
-def test_should_save_checkpoint_pickle(tmpdir: LocalPath):
-    tape = TapeCallbackFunction()
-    pickle_checkpoint_step = PickleCheckpointStep('1', tmpdir)
-    pipeline = Pipeline(
-        steps=[
-            TransformCallbackStep(tape.callback, ["1"]),
-            pickle_checkpoint_step,
-            TransformCallbackStep(tape.callback, ["2"]),
-            TransformCallbackStep(tape.callback, ["3"])
-        ]
-    )
-
-    pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
-
-    actual_tape = tape.get_name_tape()
-    assert actual_data_inputs == data_inputs
-    assert actual_tape == ["1", "2", "3"]
-    assert os.path.exists(pickle_checkpoint_step.get_checkpoint_file_path(data_inputs))
-
-
-def test_should_load_checkpoint_pickle(tmpdir: LocalPath):
-    tape = TapeCallbackFunction()
-    force_checkpoint_name = 'checkpoint_a'
-    pickle_checkpoint_step = PickleCheckpointStep(
-        force_checkpoint_name=force_checkpoint_name,
-        cache_folder=tmpdir
-    )
-    pickle_checkpoint_step.set_checkpoint_path(force_checkpoint_name)
-    with open(pickle_checkpoint_step.get_checkpoint_file_path(data_inputs), 'wb') as file:
-        pickle.dump(data_inputs, file)
-
+def create_pipeline_without_hyperparams(pickle_checkpoint_step, tape):
     pipeline = Pipeline(
         steps=[
             ('a', TransformCallbackStep(tape.callback, ["1"])),
-            ('b', TransformCallbackStep(tape.callback, ["2"])),
-            (force_checkpoint_name, pickle_checkpoint_step),
-            ('c', TransformCallbackStep(tape.callback, ["3"]))
+            ('pickle_checkpoint', pickle_checkpoint_step),
+            ('c', TransformCallbackStep(tape.callback, ["2"])),
+            ('d', TransformCallbackStep(tape.callback, ["3"]))
         ]
     )
+    return pipeline
+
+
+def create_pipeline_with_hyperparams(pickle_checkpoint_step, tape):
+    pipeline = Pipeline(
+        steps=[
+            ('a',
+             TransformCallbackStep(tape.callback, ["1"], hyperparams=HyperparameterSamples({"a__learning_rate": 1}))),
+            ('pickle_checkpoint', pickle_checkpoint_step),
+            ('c', TransformCallbackStep(tape.callback, ["2"])),
+            ('d', TransformCallbackStep(tape.callback, ["3"]))
+        ]
+    )
+    return pipeline
+
+
+def test_when_no_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
+    tape = TapeCallbackFunction()
+    pickle_checkpoint_step = create_pickle_checkpoint_step(tmpdir)
+    pipeline = create_pipeline_without_hyperparams(pickle_checkpoint_step, tape)
 
     pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
 
     actual_tape = tape.get_name_tape()
-    assert actual_data_inputs == data_inputs
-    assert actual_tape == ["3"]
+    assert np.array_equal(actual_data_inputs, data_inputs)
+    assert actual_tape == ["1", "2", "3"]
+    assert os.path.exists(pickle_checkpoint_step.get_checkpoint_file_path(0))
+    assert os.path.exists(pickle_checkpoint_step.get_checkpoint_file_path(1))
+
+
+def test_when_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
+    tape = TapeCallbackFunction()
+    pickle_checkpoint_step = create_pickle_checkpoint_step(tmpdir)
+    pipeline = create_pipeline_with_hyperparams(pickle_checkpoint_step, tape)
+
+    pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
+
+    actual_tape = tape.get_name_tape()
+    assert np.array_equal(actual_data_inputs, data_inputs)
+    assert actual_tape == ["1", "2", "3"]
+    assert os.path.exists(pickle_checkpoint_step.get_checkpoint_file_path(expected_rehashed_data_inputs[0]))
+    assert os.path.exists(pickle_checkpoint_step.get_checkpoint_file_path(expected_rehashed_data_inputs[1]))
+
+
+def test_when_no_hyperparams_should_load_checkpoint_pickle(tmpdir: LocalPath):
+    tape = TapeCallbackFunction()
+    pickle_checkpoint_step = create_pickle_checkpoint_step(tmpdir)
+    setup_pickle_checkpoint(
+        current_id=0,
+        data_input=data_inputs[0],
+        expected_output=expected_outputs[0],
+        pickle_checkpoint_step=pickle_checkpoint_step
+    )
+    setup_pickle_checkpoint(
+        current_id=1,
+        data_input=data_inputs[1],
+        expected_output=expected_outputs[1],
+        pickle_checkpoint_step=pickle_checkpoint_step
+    )
+    pipeline = create_pipeline_without_hyperparams(pickle_checkpoint_step, tape)
+
+    pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
+
+    actual_tape = tape.get_name_tape()
+    assert np.array_equal(actual_data_inputs, data_inputs)
+    assert actual_tape == EXPECTED_TAPE_AFTER_CHECKPOINT
+
+
+def test_when_hyperparams_should_load_checkpoint_pickle(tmpdir: LocalPath):
+    tape = TapeCallbackFunction()
+    pickle_checkpoint_step = create_pickle_checkpoint_step(tmpdir)
+    setup_pickle_checkpoint(
+        current_id=expected_rehashed_data_inputs[0],
+        data_input=data_inputs[0],
+        expected_output=expected_outputs[0],
+        pickle_checkpoint_step=pickle_checkpoint_step
+    )
+    setup_pickle_checkpoint(
+        current_id=expected_rehashed_data_inputs[1],
+        data_input=data_inputs[1],
+        expected_output=expected_outputs[1],
+        pickle_checkpoint_step=pickle_checkpoint_step
+    )
+
+    pipeline = create_pipeline_with_hyperparams(pickle_checkpoint_step, tape)
+
+    pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
+
+    actual_tape = tape.get_name_tape()
+    assert np.array_equal(actual_data_inputs, data_inputs)
+    assert actual_tape == EXPECTED_TAPE_AFTER_CHECKPOINT
+
+
+def setup_pickle_checkpoint(current_id, data_input, expected_output, pickle_checkpoint_step):
+    with open(pickle_checkpoint_step.get_checkpoint_file_path(current_id), 'wb') as file:
+        pickle.dump((current_id, data_input, expected_output), file)
+
+
+def create_pickle_checkpoint_step(tmpdir):
+    pickle_checkpoint_step = PickleCheckpointStep(cache_folder=tmpdir)
+    pickle_checkpoint_step.set_checkpoint_path(os.path.join('Pipeline', 'pickle_checkpoint'))
+    return pickle_checkpoint_step

--- a/testing/test_pipeline.py
+++ b/testing/test_pipeline.py
@@ -22,7 +22,7 @@ Tests for Pipelines
 import numpy as np
 import pytest
 
-from neuraxle.base import BaseStep, HasherByIndex
+from neuraxle.base import BaseStep, RangeHasher
 from neuraxle.hyperparams.distributions import RandInt, LogUniform
 from neuraxle.hyperparams.space import nested_dict_to_flat, HyperparameterSpace
 from neuraxle.pipeline import Pipeline
@@ -36,7 +36,7 @@ AN_EXPECTED_OUTPUT = "I am an expected output"
 
 
 class SomeStep(BaseStep):
-    def __init__(self, hyperparams_space: HyperparameterSpace = None, hasher=HasherByIndex()):
+    def __init__(self, hyperparams_space: HyperparameterSpace = None, hasher=RangeHasher()):
         super().__init__(hyperparams=None, hyperparams_space=hyperparams_space, hasher=hasher)
 
     def fit_one(self, data_input, expected_output=None) -> 'SomeStep':
@@ -54,6 +54,8 @@ steps_lists = [
         ("some_step_3", SomeStep())
     ]
 ]
+
+
 @pytest.mark.parametrize("steps_list", steps_lists)
 def test_pipeline_fit_transform(steps_list):
     data_input_ = [AN_INPUT]

--- a/testing/test_pipeline.py
+++ b/testing/test_pipeline.py
@@ -22,7 +22,7 @@ Tests for Pipelines
 import numpy as np
 import pytest
 
-from neuraxle.base import BaseStep
+from neuraxle.base import BaseStep, HasherByIndex
 from neuraxle.hyperparams.distributions import RandInt, LogUniform
 from neuraxle.hyperparams.space import nested_dict_to_flat, HyperparameterSpace
 from neuraxle.pipeline import Pipeline
@@ -36,9 +36,8 @@ AN_EXPECTED_OUTPUT = "I am an expected output"
 
 
 class SomeStep(BaseStep):
-
-    def __init__(self, hyperparams_space: HyperparameterSpace = None):
-        super().__init__(None, hyperparams_space)
+    def __init__(self, hyperparams_space: HyperparameterSpace = None, hasher=HasherByIndex()):
+        super().__init__(hyperparams=None, hyperparams_space=hyperparams_space, hasher=hasher)
 
     def fit_one(self, data_input, expected_output=None) -> 'SomeStep':
         return self

--- a/testing/test_pipeline.py
+++ b/testing/test_pipeline.py
@@ -355,10 +355,12 @@ def test_hyperparam_space():
 
     hyperparams = p.get_hyperparams()
 
-    assert 'AddFeatures__SomeStep1__n_components' in hyperparams.keys()
-    assert 'AddFeatures__SomeStep__n_components' in hyperparams.keys()
-    assert 'AddFeatures__SomeStep1__n_components' in hyperparams.keys()
-    assert 'ModelStacking__SomeStep__n_estimators' in hyperparams.keys()
-    assert 'ModelStacking__SomeStep1__n_estimators' in hyperparams.keys()
-    assert 'ModelStacking__SomeStep2__max_depth' in hyperparams.keys()
-    assert 'ModelStacking__SomeStep3__max_depth' in hyperparams.keys()
+    assert "AddFeatures" in hyperparams.keys()
+    assert "SomeStep" in hyperparams["AddFeatures"]
+    assert "n_components" in hyperparams["AddFeatures"]["SomeStep"]
+    assert "SomeStep1" in hyperparams["AddFeatures"]
+    assert "n_components" in hyperparams["AddFeatures"]["SomeStep1"]
+    assert "SomeStep" in hyperparams["ModelStacking"]
+    assert "n_estimators" in hyperparams["ModelStacking"]["SomeStep"]
+    assert "SomeStep1" in hyperparams["ModelStacking"]
+    assert "max_depth" in hyperparams["ModelStacking"]["SomeStep2"]

--- a/testing/test_pipeline.py
+++ b/testing/test_pipeline.py
@@ -355,12 +355,10 @@ def test_hyperparam_space():
 
     hyperparams = p.get_hyperparams()
 
-    assert "AddFeatures" in hyperparams.keys()
-    assert "SomeStep" in hyperparams["AddFeatures"]
-    assert "n_components" in hyperparams["AddFeatures"]["SomeStep"]
-    assert "SomeStep1" in hyperparams["AddFeatures"]
-    assert "n_components" in hyperparams["AddFeatures"]["SomeStep1"]
-    assert "SomeStep" in hyperparams["ModelStacking"]
-    assert "n_estimators" in hyperparams["ModelStacking"]["SomeStep"]
-    assert "SomeStep1" in hyperparams["ModelStacking"]
-    assert "max_depth" in hyperparams["ModelStacking"]["SomeStep2"]
+    assert 'AddFeatures__SomeStep1__n_components' in hyperparams.keys()
+    assert 'AddFeatures__SomeStep__n_components' in hyperparams.keys()
+    assert 'AddFeatures__SomeStep1__n_components' in hyperparams.keys()
+    assert 'ModelStacking__SomeStep__n_estimators' in hyperparams.keys()
+    assert 'ModelStacking__SomeStep1__n_estimators' in hyperparams.keys()
+    assert 'ModelStacking__SomeStep2__max_depth' in hyperparams.keys()
+    assert 'ModelStacking__SomeStep3__max_depth' in hyperparams.keys()

--- a/testing/test_pipeline_hashing.py
+++ b/testing/test_pipeline_hashing.py
@@ -1,0 +1,255 @@
+from typing import List, Any
+
+import numpy as np
+import pytest
+
+from neuraxle.base import NamedTupleList, BaseHasher
+from neuraxle.checkpoints import BaseCheckpointStep
+from neuraxle.hyperparams.space import HyperparameterSamples
+from neuraxle.pipeline import Pipeline
+from neuraxle.steps.util import TransformCallbackStep
+from testing.test_resumable_pipeline import SomeCheckpointStep, tape
+
+
+class ResumablePipelineTestCase:
+    def __init__(self, steps: NamedTupleList, expected_tape: List[str], di, eo=None, expected_rehashed_ids=None):
+        self.expected_outputs = eo
+        self.data_inputs = di
+        self.steps = steps
+        self.expected_tape = expected_tape
+        self.expected_rehashed_ids = expected_rehashed_ids
+
+
+class MockHasher(BaseHasher):
+    def hash(self, current_ids, hyperparameters: HyperparameterSamples, data_inputs: Any):
+        if current_ids is None:
+            current_ids = list(range(len(data_inputs)))
+            current_ids = [str(c) for c in current_ids]
+
+        if isinstance(hyperparameters, dict):
+            hyperparameters = HyperparameterSamples(hyperparameters)
+
+        items = ",".join([str(value) for prop, value in hyperparameters.to_flat().items()])
+
+        return [
+            ",".join([str(current_id), items])
+            for current_id in current_ids
+        ]
+
+
+def create_callback_step(tape_step_name, hyperparams):
+    step = (
+        tape_step_name,
+        TransformCallbackStep(
+            callback_function=tape.callback,
+            more_arguments=[tape_step_name],
+            hyperparams=HyperparameterSamples(hyperparams)
+        )
+    )
+    return step
+
+
+def find_checkpoint(steps):
+    for name, step in steps:
+        if isinstance(step, Pipeline):
+            return find_checkpoint(step.steps_as_tuple)
+        if isinstance(step, BaseCheckpointStep):
+            return step
+    return None
+
+
+def set_hasher(steps, hasher):
+    for name, step in steps:
+        step.set_hasher(hasher)
+        if isinstance(step, Pipeline):
+            set_hasher(step.steps_as_tuple, hasher)
+        if isinstance(step, BaseCheckpointStep):
+            return step
+    return None
+
+
+one_step_with_empty_hyperparameters = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {}),
+        ("checkpoint", SomeCheckpointStep()),
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a"],
+    expected_rehashed_ids=['0,,', '1,,'],
+)
+
+steps_with_empty_hyperparameters = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {}),
+        create_callback_step("b", {}),
+        ("checkpoint", SomeCheckpointStep()),
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a", "b"],
+    expected_rehashed_ids=['0,,,', '1,,,'],
+)
+
+steps_with_empty_hyperparameters_sub_pipeline = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {}),
+        create_callback_step("b", {}),
+        Pipeline([
+            create_callback_step("c", {}),
+            create_callback_step("d", {}),
+            ("checkpoint", SomeCheckpointStep()),
+        ])
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a", "b"],
+    expected_rehashed_ids=['0,,,,,,', '1,,,,,,'],
+)
+
+one_step_with_hyperparameters = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {"a__learning_rate": 1}),
+        ("checkpoint", SomeCheckpointStep()),
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a"],
+    expected_rehashed_ids=['0,,1', '1,,1'],
+)
+
+steps_with_hyperparameters = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {"a__learning_rate": 1}),
+        create_callback_step("b", {"b__learning_rate": 2}),
+        ("checkpoint", SomeCheckpointStep()),
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a", "b"],
+    expected_rehashed_ids=['0,,1,2', '1,,1,2'],
+)
+
+steps_with_hyperparameters_sub_pipeline = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {"a__learning_rate": 1}),
+        create_callback_step("b", {"b__learning_rate": 2}),
+        Pipeline([
+            create_callback_step("c", {"c__learning_rate": 3}),
+            create_callback_step("d", {"d__learning_rate": 4}),
+            ("checkpoint", SomeCheckpointStep()),
+        ])
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a", "b"],
+    expected_rehashed_ids=['0,,1,2,3,4,', '1,,1,2,3,4,'],
+)
+
+one_step_with_nested_hyperparameters = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {"a": {"learning_rate": 1}}),
+        ("checkpoint", SomeCheckpointStep()),
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a"],
+    expected_rehashed_ids=['0,,1', '1,,1'],
+)
+
+steps_with_nested_hyperparameters = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {"a": {"learning_rate": 1}}),
+        create_callback_step("b", {"b": {"learning_rate": 2}}),
+        ("checkpoint", SomeCheckpointStep()),
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a", "b"],
+    expected_rehashed_ids=['0,,1,2', '1,,1,2'],
+)
+
+steps_with_nested_hyperparameters_sub_pipeline = ResumablePipelineTestCase(
+    steps=[
+        create_callback_step("a", {"a": {"learning_rate": 1}}),
+        create_callback_step("b", {"b": {"learning_rate": 2}}),
+        Pipeline([
+            create_callback_step("c", {"c": {"learning_rate": 3}}),
+            create_callback_step("d", {"d": {"learning_rate": 4}}),
+            ("checkpoint", SomeCheckpointStep()),
+        ])
+    ],
+    di=np.array([1, 2]),
+    eo=np.array([1, 2]),
+    expected_tape=["a", "b"],
+    expected_rehashed_ids=['0,,1,2,3,4,', '1,,1,2,3,4,'],
+)
+
+
+@pytest.mark.parametrize("test_case", [
+    one_step_with_empty_hyperparameters,
+    steps_with_empty_hyperparameters,
+    steps_with_empty_hyperparameters_sub_pipeline,
+    one_step_with_hyperparameters,
+    steps_with_hyperparameters,
+    steps_with_hyperparameters_sub_pipeline,
+    one_step_with_nested_hyperparameters,
+    steps_with_nested_hyperparameters,
+    steps_with_nested_hyperparameters_sub_pipeline
+])
+def test_transform_should_rehash_hyperparameters_for_each_steps(test_case: ResumablePipelineTestCase):
+    pipeline = Pipeline(steps=test_case.steps)
+    tape.data = []
+    tape.name_tape = []
+    pipeline.set_hasher(MockHasher())
+    set_hasher(pipeline.steps_as_tuple, MockHasher())
+
+    pipeline.transform(test_case.data_inputs)
+
+    mocked_checkpoint = find_checkpoint(pipeline.steps_as_tuple)
+    actual_rehashed_ids = mocked_checkpoint.saved_data_container.current_ids
+    assert actual_rehashed_ids == test_case.expected_rehashed_ids
+
+
+@pytest.mark.parametrize("test_case", [
+    one_step_with_empty_hyperparameters,
+    steps_with_empty_hyperparameters,
+    steps_with_empty_hyperparameters_sub_pipeline,
+    one_step_with_hyperparameters,
+    steps_with_hyperparameters,
+    steps_with_hyperparameters_sub_pipeline
+])
+def test_fit_should_rehash_hyperparameters_for_each_steps(test_case: ResumablePipelineTestCase):
+    pipeline = Pipeline(steps=test_case.steps)
+    tape.data = []
+    tape.name_tape = []
+    pipeline.set_hasher(MockHasher())
+    set_hasher(pipeline.steps_as_tuple, MockHasher())
+
+    pipeline.fit(test_case.data_inputs, test_case.expected_outputs)
+
+    mocked_checkpoint = find_checkpoint(pipeline.steps_as_tuple)
+    actual_rehashed_ids = mocked_checkpoint.saved_data_container.current_ids
+    assert actual_rehashed_ids == test_case.expected_rehashed_ids
+
+
+@pytest.mark.parametrize("test_case", [
+    one_step_with_empty_hyperparameters,
+    steps_with_empty_hyperparameters,
+    steps_with_empty_hyperparameters_sub_pipeline,
+    one_step_with_hyperparameters,
+    steps_with_hyperparameters,
+    steps_with_hyperparameters_sub_pipeline
+])
+def test_fit_transform_should_rehash_hyperparameters_for_each_steps(test_case: ResumablePipelineTestCase):
+    pipeline = Pipeline(steps=test_case.steps)
+    tape.data = []
+    tape.name_tape = []
+    pipeline.set_hasher(MockHasher())
+    set_hasher(pipeline.steps_as_tuple, MockHasher())
+
+    pipeline.fit_transform(test_case.data_inputs, test_case.expected_outputs)
+
+    mocked_checkpoint = find_checkpoint(pipeline.steps_as_tuple)
+    actual_rehashed_ids = mocked_checkpoint.saved_data_container.current_ids
+    assert actual_rehashed_ids == test_case.expected_rehashed_ids

--- a/testing/test_pipeline_hashing.py
+++ b/testing/test_pipeline_hashing.py
@@ -27,7 +27,7 @@ class MockHasher(BaseHasher):
             current_ids = list(range(len(data_inputs)))
             current_ids = [str(c) for c in current_ids]
 
-        if hyperparameters == {}:
+        if len(hyperparameters) == 0:
             return current_ids
         else:
             items = ",".join([str(value) for prop, value in hyperparameters.to_flat().items()])

--- a/testing/test_pipeline_hashing.py
+++ b/testing/test_pipeline_hashing.py
@@ -196,6 +196,7 @@ def create_test_cases():
         expected_rehashed_ids=['0,1,2,3,4', '1,1,2,3,4'],
     )
 
+
     return [
         one_step_with_empty_hyperparameters,
         steps_with_empty_hyperparameters,

--- a/testing/test_resumable_pipeline.py
+++ b/testing/test_resumable_pipeline.py
@@ -203,6 +203,20 @@ def create_test_cases():
         ],
         ["3"])
 
+    tape11 = TapeCallbackFunction()
+    tape_multiple_checkpoint_in_a_row = ResumablePipelineTestCase(
+        tape11,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape11.callback, ["1"])),
+            ("pickle_1", SomeCheckpointStep(data_container=dc)),
+            ("pickle_2", SomeCheckpointStep(data_container=dc)),
+            ("c", TransformCallbackStep(tape11.callback, ["2"])),
+            ("d", TransformCallbackStep(tape11.callback, ["3"]))
+        ],
+        ["2", "3"])
+
     return [
         tape_without_checkpoint_test_arguments,
         tape_checkpoint_not_saved_test_arguments,
@@ -213,7 +227,8 @@ def create_test_cases():
         tape_checkpoint_saved_inside_subpipeline_last_step,
         tape_checkpoint_saved_inside_subpipeline_step_in_the_middle,
         tape_checkpoint_saved_inside_subpipeline_of_subpipeline,
-        tape_saved_checkpoint_after_another_saved_checkpoint
+        tape_saved_checkpoint_after_another_saved_checkpoint,
+        tape_multiple_checkpoint_in_a_row
     ]
 
 

--- a/testing/test_resumable_pipeline.py
+++ b/testing/test_resumable_pipeline.py
@@ -1,9 +1,7 @@
-from typing import List
-
 import numpy as np
 import pytest
 
-from neuraxle.base import BaseStep, DataContainer
+from neuraxle.base import DataContainer
 from neuraxle.checkpoints import BaseCheckpointStep
 from neuraxle.pipeline import Pipeline
 from neuraxle.steps.util import TransformCallbackStep, TapeCallbackFunction
@@ -31,188 +29,228 @@ class SomeCheckpointStep(BaseCheckpointStep):
         return self.saved_data_container is not None
 
 
-data_inputs = np.ones((1, 1))
-expected_outputs = np.ones((1, 1))
-dc = DataContainer(current_ids=range(len(data_inputs)), data_inputs=data_inputs, expected_outputs=expected_outputs)
-tape = TapeCallbackFunction()
+class ResumablePipelineTestCase:
+    def __init__(self, tape, data_inputs, expected_outputs, steps, expected_tape):
+        self.steps = steps
+        self.expected_outputs = expected_outputs
+        self.expected_tape = expected_tape
+        self.data_inputs = data_inputs
+        self.tape = tape
 
-tape_without_checkpoint_test_arguments = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        ("b", TransformCallbackStep(tape.callback, ["2"])),
-        ("c", TransformCallbackStep(tape.callback, ["3"]))
-    ],
-    ["1", "2", "3"])
 
-tape_checkpoint_not_saved_test_arguments = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        ("b", SomeCheckpointStep(data_container=None)
-         ),
-        ("c", TransformCallbackStep(tape.callback, ["2"])),
-        ("d", TransformCallbackStep(tape.callback, ["3"]))
-    ],
-    ["1", "2", "3"])
+def create_test_case(di, eo, steps, expected_tape):
+    tape = TapeCallbackFunction()
+    return ResumablePipelineTestCase(tape, di, eo, steps, expected_tape)
 
-tape_checkpoint_saved_after_first_step_test_arguments = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        ("b", SomeCheckpointStep(data_container=dc)
-         ),
-        ("c", TransformCallbackStep(tape.callback, ["2"])),
-        ("d", TransformCallbackStep(tape.callback, ["3"]))
-    ],
-    ["2", "3"])
 
-tape_checkpoint_saved_after_second_step_test_arguments = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        ("b", TransformCallbackStep(tape.callback, ["2"])),
-        ("c", SomeCheckpointStep(data_container=dc)
-         ),
-        ("d", TransformCallbackStep(tape.callback, ["3"]))
-    ],
-    ["3"])
+def create_test_cases():
+    data_inputs = np.ones((1, 1))
+    expected_outputs = np.ones((1, 1))
+    dc = DataContainer(current_ids=range(len(data_inputs)), data_inputs=data_inputs, expected_outputs=expected_outputs)
 
-tape_checkpoint_saved_after_last_step_test_arguments = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        ("b", TransformCallbackStep(tape.callback, ["2"])),
-        ("c", TransformCallbackStep(tape.callback, ["3"])),
-        ("d", SomeCheckpointStep(data_container=dc)
-         ),
-    ],
-    [])
-
-tape_checkpoint_saved_inside_subpipeline_last_step = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        Pipeline([
+    tape = TapeCallbackFunction()
+    tape_without_checkpoint_test_arguments = ResumablePipelineTestCase(
+        tape,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape.callback, ["1"])),
             ("b", TransformCallbackStep(tape.callback, ["2"])),
+            ("c", TransformCallbackStep(tape.callback, ["3"]))
+        ],
+        ["1", "2", "3"])
+
+    tape2 = TapeCallbackFunction()
+    tape_checkpoint_not_saved_test_arguments = ResumablePipelineTestCase(
+        tape2,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape2.callback, ["1"])),
+            ("b", SomeCheckpointStep(data_container=None)
+             ),
+            ("c", TransformCallbackStep(tape2.callback, ["2"])),
+            ("d", TransformCallbackStep(tape2.callback, ["3"]))
+        ],
+        ["1", "2", "3"])
+
+    tape3 = TapeCallbackFunction()
+    tape_checkpoint_saved_after_first_step_test_arguments = ResumablePipelineTestCase(
+        tape3,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape3.callback, ["1"])),
+            ("b", SomeCheckpointStep(data_container=dc)
+             ),
+            ("c", TransformCallbackStep(tape3.callback, ["2"])),
+            ("d", TransformCallbackStep(tape3.callback, ["3"]))
+        ],
+        ["2", "3"])
+
+    tape4 = TapeCallbackFunction()
+    tape_checkpoint_saved_after_second_step_test_arguments = ResumablePipelineTestCase(
+        tape4,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape4.callback, ["1"])),
+            ("b", TransformCallbackStep(tape4.callback, ["2"])),
+            ("c", SomeCheckpointStep(data_container=dc)
+             ),
+            ("d", TransformCallbackStep(tape4.callback, ["3"]))
+        ],
+        ["3"])
+
+    tape5 = TapeCallbackFunction()
+    tape_checkpoint_saved_after_last_step_test_arguments = ResumablePipelineTestCase(
+        tape5,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape5.callback, ["1"])),
+            ("b", TransformCallbackStep(tape5.callback, ["2"])),
+            ("c", TransformCallbackStep(tape5.callback, ["3"])),
             ("d", SomeCheckpointStep(data_container=dc)
              ),
-        ]),
-        ("e", TransformCallbackStep(tape.callback, ["3"])),
-        ("f", TransformCallbackStep(tape.callback, ["4"])),
-    ],
-    ["3", "4"])
+        ],
+        [])
 
-tape_checkpoint_saved_inside_subpipeline_first_step = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        Pipeline([
-            ("d", SomeCheckpointStep(data_container=dc)
-             ),
-            ("b", TransformCallbackStep(tape.callback, ["2"])),
-        ]),
-        ("e", TransformCallbackStep(tape.callback, ["3"])),
-        ("f", TransformCallbackStep(tape.callback, ["4"])),
-    ],
-    ["2", "3", "4"])
-
-tape_checkpoint_saved_inside_subpipeline_step_in_the_middle = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        Pipeline([
-            ("b", TransformCallbackStep(tape.callback, ["2"])),
-            ("d", SomeCheckpointStep(data_container=dc)
-             ),
-            ("e", TransformCallbackStep(tape.callback, ["3"])),
-        ]),
-        ("f", TransformCallbackStep(tape.callback, ["4"])),
-    ],
-    ["3", "4"])
-
-tape_checkpoint_saved_inside_subpipeline_of_subpipeline = (
-    [
-        ("a", TransformCallbackStep(tape.callback, ["1"])),
-        Pipeline([
-            ("b", TransformCallbackStep(tape.callback, ["2"])),
+    tape6 = TapeCallbackFunction()
+    tape_checkpoint_saved_inside_subpipeline_last_step = ResumablePipelineTestCase(
+        tape6,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape6.callback, ["1"])),
             Pipeline([
-                ("e", TransformCallbackStep(tape.callback, ["3"])),
+                ("b", TransformCallbackStep(tape6.callback, ["2"])),
                 ("d", SomeCheckpointStep(data_container=dc)
                  ),
-                ("f", TransformCallbackStep(tape.callback, ["4"])),
             ]),
-            ("g", TransformCallbackStep(tape.callback, ["5"])),
-        ]),
-        ("h", TransformCallbackStep(tape.callback, ["6"])),
-    ],
-    ["4", "5", "6"])
+            ("e", TransformCallbackStep(tape6.callback, ["3"])),
+            ("f", TransformCallbackStep(tape6.callback, ["4"])),
+        ],
+        ["3", "4"])
+
+    tape7 = TapeCallbackFunction()
+    tape_checkpoint_saved_inside_subpipeline_first_step = ResumablePipelineTestCase(
+        tape7,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape7.callback, ["1"])),
+            Pipeline([
+                ("d", SomeCheckpointStep(data_container=dc)
+                 ),
+                ("b", TransformCallbackStep(tape7.callback, ["2"])),
+            ]),
+            ("e", TransformCallbackStep(tape7.callback, ["3"])),
+            ("f", TransformCallbackStep(tape7.callback, ["4"])),
+        ],
+        ["2", "3", "4"])
+
+    tape8 = TapeCallbackFunction()
+    tape_checkpoint_saved_inside_subpipeline_step_in_the_middle = ResumablePipelineTestCase(
+        tape8,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape8.callback, ["1"])),
+            Pipeline([
+                ("b", TransformCallbackStep(tape8.callback, ["2"])),
+                ("d", SomeCheckpointStep(data_container=dc)
+                 ),
+                ("e", TransformCallbackStep(tape8.callback, ["3"])),
+            ]),
+            ("f", TransformCallbackStep(tape8.callback, ["4"])),
+        ],
+        ["3", "4"])
+
+    tape9 = TapeCallbackFunction()
+    tape_checkpoint_saved_inside_subpipeline_of_subpipeline = ResumablePipelineTestCase(
+        tape9,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape9.callback, ["1"])),
+            Pipeline([
+                ("b", TransformCallbackStep(tape9.callback, ["2"])),
+                Pipeline([
+                    ("e", TransformCallbackStep(tape9.callback, ["3"])),
+                    ("d", SomeCheckpointStep(data_container=dc)
+                     ),
+                    ("f", TransformCallbackStep(tape9.callback, ["4"])),
+                ]),
+                ("g", TransformCallbackStep(tape9.callback, ["5"])),
+            ]),
+            ("h", TransformCallbackStep(tape9.callback, ["6"])),
+        ],
+        ["4", "5", "6"])
+
+    tape10 = TapeCallbackFunction()
+    tape_saved_checkpoint_after_another_saved_checkpoint = ResumablePipelineTestCase(
+        tape10,
+        data_inputs,
+        expected_outputs,
+        [
+            ("a", TransformCallbackStep(tape10.callback, ["1"])),
+            ("b", SomeCheckpointStep(data_container=dc)),
+            ("c", TransformCallbackStep(tape10.callback, ["2"])),
+            ("b", SomeCheckpointStep(data_container=dc)),
+            ("d", TransformCallbackStep(tape10.callback, ["3"]))
+        ],
+        ["3"])
+
+    return [
+        tape_without_checkpoint_test_arguments,
+        tape_checkpoint_not_saved_test_arguments,
+        tape_checkpoint_saved_after_first_step_test_arguments,
+        tape_checkpoint_saved_after_second_step_test_arguments,
+        tape_checkpoint_saved_after_last_step_test_arguments,
+        tape_checkpoint_saved_inside_subpipeline_first_step,
+        tape_checkpoint_saved_inside_subpipeline_last_step,
+        tape_checkpoint_saved_inside_subpipeline_step_in_the_middle,
+        tape_checkpoint_saved_inside_subpipeline_of_subpipeline,
+        tape_saved_checkpoint_after_another_saved_checkpoint
+    ]
 
 
-@pytest.mark.parametrize("steps,expected_tape", [
-    tape_without_checkpoint_test_arguments,
-    tape_checkpoint_not_saved_test_arguments,
-    tape_checkpoint_saved_after_first_step_test_arguments,
-    tape_checkpoint_saved_after_second_step_test_arguments,
-    tape_checkpoint_saved_after_last_step_test_arguments,
-    tape_checkpoint_saved_inside_subpipeline_first_step,
-    tape_checkpoint_saved_inside_subpipeline_last_step,
-    tape_checkpoint_saved_inside_subpipeline_step_in_the_middle,
-    tape_checkpoint_saved_inside_subpipeline_of_subpipeline,
-])
-def test_fit_transform(steps: List[BaseStep], expected_tape: List[str]):
-    tape.data = []
-    tape.name_tape = []
+@pytest.mark.parametrize("test_case", create_test_cases())
+def test_should_fit_transform_each_steps(test_case: ResumablePipelineTestCase):
     pipeline = Pipeline(
-        steps=steps
+        steps=test_case.steps
     )
 
-    actual_pipeline, actual_data_inputs = pipeline.fit_transform(data_inputs, expected_outputs)
+    actual_pipeline, actual_data_inputs = pipeline.fit_transform(test_case.data_inputs, test_case.expected_outputs)
 
-    actual_tape = tape.get_name_tape()
+    actual_tape = test_case.tape.get_name_tape()
     assert isinstance(actual_pipeline, Pipeline)
-    assert actual_tape == expected_tape
-    assert np.array_equal(actual_data_inputs, data_inputs)
+    assert actual_tape == test_case.expected_tape
+    assert np.array_equal(actual_data_inputs, test_case.data_inputs)
 
 
-@pytest.mark.parametrize("steps,expected_tape", [
-    tape_without_checkpoint_test_arguments,
-    tape_checkpoint_not_saved_test_arguments,
-    tape_checkpoint_saved_after_first_step_test_arguments,
-    tape_checkpoint_saved_after_second_step_test_arguments,
-    tape_checkpoint_saved_after_last_step_test_arguments,
-    tape_checkpoint_saved_inside_subpipeline_first_step,
-    tape_checkpoint_saved_inside_subpipeline_last_step,
-    tape_checkpoint_saved_inside_subpipeline_step_in_the_middle,
-    tape_checkpoint_saved_inside_subpipeline_of_subpipeline,
-])
-def test_should_fit_each_steps(steps: List[BaseStep], expected_tape: List[str]):
-    tape.data = []
-    tape.name_tape = []
+@pytest.mark.parametrize("test_case", create_test_cases())
+def test_should_fit_each_steps(test_case: ResumablePipelineTestCase):
     pipeline = Pipeline(
-        steps=steps
+        steps=test_case.steps
     )
 
-    actual_pipeline = pipeline.fit(data_inputs, expected_outputs)
+    actual_pipeline = pipeline.fit(test_case.data_inputs, test_case.expected_outputs)
 
-    actual_tape = tape.get_name_tape()
+    actual_tape = test_case.tape.get_name_tape()
     assert isinstance(actual_pipeline, Pipeline)
-    assert actual_tape == expected_tape
+    assert actual_tape == test_case.expected_tape
 
 
-@pytest.mark.parametrize("steps,expected_tape", [
-    tape_without_checkpoint_test_arguments,
-    tape_checkpoint_not_saved_test_arguments,
-    tape_checkpoint_saved_after_first_step_test_arguments,
-    tape_checkpoint_saved_after_second_step_test_arguments,
-    tape_checkpoint_saved_after_last_step_test_arguments,
-    tape_checkpoint_saved_inside_subpipeline_first_step,
-    tape_checkpoint_saved_inside_subpipeline_last_step,
-    tape_checkpoint_saved_inside_subpipeline_step_in_the_middle,
-    tape_checkpoint_saved_inside_subpipeline_of_subpipeline,
-])
-def test_should_transform_each_steps(steps: List[BaseStep], expected_tape: List[str]):
+@pytest.mark.parametrize("test_case", create_test_cases())
+def test_should_transform_each_steps(test_case: ResumablePipelineTestCase):
     pipeline = Pipeline(
-        steps=steps
+        steps=test_case.steps
     )
-    pipeline = pipeline.fit(data_inputs)
-    tape.data = []
-    tape.name_tape = []
 
-    actual_data_inputs = pipeline.transform(data_inputs)
+    actual_data_inputs = pipeline.transform(test_case.data_inputs)
 
-    actual_tape = tape.get_name_tape()
-    assert actual_tape == expected_tape
-    assert np.array_equal(actual_data_inputs, data_inputs)
+    actual_tape = test_case.tape.get_name_tape()
+    assert actual_tape == test_case.expected_tape
+    assert np.array_equal(actual_data_inputs, test_case.data_inputs)

--- a/testing/test_resumable_pipeline.py
+++ b/testing/test_resumable_pipeline.py
@@ -24,6 +24,7 @@ class SomeCheckpointStep(BaseCheckpointStep):
     def save_checkpoint(self, data_container: DataContainer):
         self.saved_data_container = data_container
         self.saved = True
+        return data_container
 
     def should_resume(self, data_container) -> bool:
         return self.saved_data_container is not None

--- a/testing/test_resumable_pipeline.py
+++ b/testing/test_resumable_pipeline.py
@@ -1,4 +1,3 @@
-import string
 from typing import List
 
 import numpy as np
@@ -13,29 +12,28 @@ from neuraxle.steps.util import TransformCallbackStep, TapeCallbackFunction
 class SomeCheckpointStep(BaseCheckpointStep):
     def __init__(self, data_container: DataContainer = None):
         super().__init__()
-        self.data_container = data_container
         self.saved = False
-        self.saved_data_container = None
+        self.saved_data_container = data_container
+        self.checkpoint_path = None
 
     def set_checkpoint_path(self, path):
+        self.checkpoint_path = path
         pass
 
     def read_checkpoint(self, data_container: DataContainer):
-        return self.data_container
+        return self.saved_data_container
 
     def save_checkpoint(self, data_container: DataContainer):
         self.saved_data_container = data_container
         self.saved = True
 
     def should_resume(self, data_container) -> bool:
-        return self.data_container is not None
+        return self.saved_data_container is not None
 
 
 data_inputs = np.ones((1, 1))
 expected_outputs = np.ones((1, 1))
-dc = DataContainer(ids=range(len(data_inputs)), data_inputs=data_inputs, expected_outputs=expected_outputs)
-chekpoint = SomeCheckpointStep(dc)
-chekpoint_not_saved = SomeCheckpointStep(None)
+dc = DataContainer(current_ids=range(len(data_inputs)), data_inputs=data_inputs, expected_outputs=expected_outputs)
 tape = TapeCallbackFunction()
 
 tape_without_checkpoint_test_arguments = (


### PR DESCRIPTION
Fixes #48 
Fixes #44 
Fixes #43 
Fixes #27 
Fixes #56 

1. Introduce handle_transform and handle_fit_transform method inside BaseStep to execute side effects on the new DataContainer Object after fits and transforms.

2. Introduce DataContainer Object to keep track of :
    - original_ids
    - ids
    - data inputs
    - expected outputs

3. Implement Hyperparams/ids Rehashing With hashlib md5 https://docs.python.org/3/library/hashlib.html#module-hashlib


4. Load checkpoint from hyperparameters and data_inputs inside Pipeline. 