### PR TITLE
Implement Reversible preprocessing wrapper

### DIFF
--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -752,6 +752,29 @@ class BaseStep(ABC):
         """
         return self.hyperparams_space
 
+    def handle_inverse_transform(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        """
+        Override this to add side effects or change the execution flow before (or after) calling :func:`~neuraxle.base.BaseStep.inverse_transform`.
+        The default behavior is to rehash current ids with the step hyperparameters.
+
+        :param data_container: the data container to inverse transform
+        :param context: execution context
+        :return: data_container
+
+        .. seealso::
+            :class:`DataContainer`,
+            :class:`neuraxle.pipeline.Pipeline`
+        """
+        self.is_invalidated = True
+
+        processed_outputs = self.inverse_transform(data_container.data_inputs)
+        data_container.set_data_inputs(processed_outputs)
+
+        current_ids = self.hash(data_container)
+        data_container.set_current_ids(current_ids)
+
+        return data_container
+
     def handle_fit(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
         """
         Override this to add side effects or change the execution flow before (or after) calling :func:`~neuraxle.base.BaseStep.fit`.

--- a/neuraxle/steps/flow.py
+++ b/neuraxle/steps/flow.py
@@ -459,8 +459,8 @@ class ReversiblePreprocessingWrapper(ForceMustHandleMixin, TruncableSteps):
         :return: self, data_container
         :rtype: (ReversiblePreprocessingWrapper, DataContainer)
         """
-        self.preprocessing_step, data_container = self.preprocessing_step.handle_fit(data_container, context)
-        self.post_processing_step, data_container = self.post_processing_step.handle_fit(data_container, context)
+        self.preprocessing_step, data_container = self.preprocessing_step.handle_fit_transform(data_container, context.push(self.preprocessing_step))
+        self.post_processing_step, data_container = self.post_processing_step.handle_fit(data_container, context.push(self.post_processing_step))
 
         current_ids = self.hash(data_container)
         data_container.set_current_ids(current_ids)
@@ -480,11 +480,10 @@ class ReversiblePreprocessingWrapper(ForceMustHandleMixin, TruncableSteps):
         :return: data_container
         :rtype: DataContainer
         """
-        data_container = self.preprocessing_step.handle_transform(data_container, context)
-        data_container = self.post_processing_step.handle_transform(data_container, context)
+        data_container = self.preprocessing_step.handle_transform(data_container, context.push(self.post_processing_step))
+        data_container = self.post_processing_step.handle_transform(data_container, context.push(self.post_processing_step))
 
-        processed_outputs = self.preprocessing_step.inverse_transform(data_container.data_inputs)
-        data_container.set_data_inputs(processed_outputs)
+        data_container = self.preprocessing_step.handle_inverse_transform(data_container, context.push(self.preprocessing_step))
 
         current_ids = self.hash(data_container)
         data_container.set_current_ids(current_ids)
@@ -504,13 +503,12 @@ class ReversiblePreprocessingWrapper(ForceMustHandleMixin, TruncableSteps):
         :return: (self, data_container)
         :rtype: (ReversiblePreprocessingWrapper, DataContainer)
         """
-        self.preprocessing_step, data_container = self.preprocessing_step.handle_fit_transform(data_container, context)
-        self.post_processing_step, data_container = self.post_processing_step.handle_fit_transform(data_container,
-                                                                                                   context)
+        self.preprocessing_step, data_container = self.preprocessing_step.handle_fit_transform(data_container, context.push(self.preprocessing_step))
+        self.post_processing_step, data_container = self.post_processing_step.handle_fit_transform(data_container, context.push(self.post_processing_step))
 
-        processed_outputs = self.preprocessing_step.inverse_transform(data_container.data_inputs)
-        data_container.set_data_inputs(processed_outputs)
+        data_container = self.preprocessing_step.handle_inverse_transform(data_container, context.push(self.preprocessing_step))
+
         current_ids = self.hash(data_container)
         data_container.set_current_ids(current_ids)
 
-        return data_container
+        return self, data_container

--- a/neuraxle/steps/numpy.py
+++ b/neuraxle/steps/numpy.py
@@ -173,6 +173,24 @@ class NumpyShapePrinter(NonFittableMixin, BaseStep):
 
 
 class MultiplyByN(NonFittableMixin, BaseStep):
+    """
+    Step to multiply a numpy array.
+    Accepts an integer for the number to multiply by.
+
+    Example usage:
+
+    .. code-block:: python
+
+        pipeline = Pipeline([
+            MultiplyByN(3)
+        ])
+        outputs = pipeline.transform(np.array([1])
+        # outputs => np.array([3])
+
+    .. seealso::
+        :class:`NonFittableMixin`,
+        :class:`BaseStep`
+    """
     def __init__(self, multiply_by=1):
         NonFittableMixin.__init__(self)
         BaseStep.__init__(
@@ -193,6 +211,47 @@ class MultiplyByN(NonFittableMixin, BaseStep):
             data_inputs = np.array(data_inputs)
 
         return data_inputs / self.hyperparams['multiply_by']
+
+
+class AddN(NonFittableMixin, BaseStep):
+    """
+    Step to add a scalar to a numpy array.
+    Accepts an integer for the number to add to every data inputs.
+
+    Example usage:
+
+    .. code-block:: python
+
+        pipeline = Pipeline([
+            AddN(1)
+        ])
+        outputs = pipeline.transform(np.array([1])
+        # outputs => np.array([2])
+
+    .. seealso::
+        :class:`NonFittableMixin`,
+        :class:`BaseStep`
+    """
+    def __init__(self, add=1):
+        NonFittableMixin.__init__(self)
+        BaseStep.__init__(
+            self,
+            hyperparams=HyperparameterSamples({
+                'add': add
+            })
+        )
+
+    def transform(self, data_inputs):
+        if not isinstance(data_inputs, np.ndarray):
+            data_inputs = np.array(data_inputs)
+
+        return data_inputs + self.hyperparams['add']
+
+    def inverse_transform(self, data_inputs):
+        if not isinstance(data_inputs, np.ndarray):
+            data_inputs = np.array(data_inputs)
+
+        return data_inputs - self.hyperparams['add']
 
 
 class OneHotEncoder(NonFittableMixin, BaseStep):

--- a/neuraxle/steps/output_handlers.py
+++ b/neuraxle/steps/output_handlers.py
@@ -38,6 +38,15 @@ class OutputTransformerWrapper(MetaStepMixin, BaseStep):
         BaseStep.__init__(self)
 
     def handle_transform(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        """
+        Handle transform by passing expected outputs to the wrapped step transform method.
+        Update the expected outputs with the outputs.
+
+        :param context: execution context
+        :param data_container:
+        :return: data container
+        :rtype: DataContainer
+        """
         new_expected_outputs_data_container = self.wrapped.handle_transform(
             DataContainer(
                 current_ids=data_container.current_ids,
@@ -55,6 +64,15 @@ class OutputTransformerWrapper(MetaStepMixin, BaseStep):
         return data_container
 
     def handle_fit(self, data_container: DataContainer, context: ExecutionContext) -> (BaseStep, DataContainer):
+        """
+        Handle fit by passing expected outputs to the wrapped step fit method.
+
+        :param context: execution context
+        :type context: ExecutionContext
+        :param data_container: data container to fit on
+        :return: self, data container
+        :rtype: (BaseStep, DataContainer)
+        """
         self.wrapped = self.wrapped.handle_fit(
             DataContainer(
                 current_ids=data_container.current_ids,
@@ -69,8 +87,17 @@ class OutputTransformerWrapper(MetaStepMixin, BaseStep):
 
         return self, data_container
 
-    def handle_fit_transform(self, data_container: DataContainer, context: ExecutionContext) -> (
-    BaseStep, DataContainer):
+    def handle_fit_transform(self, data_container: DataContainer, context: ExecutionContext) -> (BaseStep, DataContainer):
+        """
+        Handle fit transform by passing expected outputs to the wrapped step fit method.
+        Update the expected outputs with the outputs.
+
+        :param context: execution context
+        :type context: ExecutionContext
+        :param data_container: data container to fit on
+        :return: self, data container
+        :rtype: (BaseStep, DataContainer)
+        """
         self.wrapped, new_expected_outputs_data_container = self.wrapped.handle_fit_transform(
             DataContainer(
                 current_ids=data_container.current_ids,
@@ -87,10 +114,42 @@ class OutputTransformerWrapper(MetaStepMixin, BaseStep):
 
         return self, data_container
 
+    def handle_inverse_transform(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        """
+        Handle inverse transform by passing expected outputs to the wrapped step inverse transform method.
+        Update the expected outputs with the outputs.
+
+        :param context: execution context
+        :param data_container:
+        :return: data container
+        :rtype: DataContainer
+        """
+        new_expected_outputs_data_container = self.wrapped.handle_inverse_transform(
+            DataContainer(
+                current_ids=data_container.current_ids,
+                data_inputs=data_container.expected_outputs,
+                expected_outputs=None
+            ),
+            context.push(self.wrapped)
+        )
+
+        data_container.set_expected_outputs(new_expected_outputs_data_container.data_inputs)
+
+        current_ids = self.hash(data_container)
+        data_container.set_current_ids(current_ids)
+
+        return data_container
+
     def fit(self, data_inputs, expected_outputs=None):
         raise NotImplementedError('must be used inside a pipeline')
 
+    def fit_transform(self, data_inputs, expected_outputs=None):
+        raise NotImplementedError('must be used inside a pipeline')
+
     def transform(self, data_inputs):
+        raise NotImplementedError('must be used inside a pipeline')
+
+    def inverse_transform(self, processed_outputs):
         raise NotImplementedError('must be used inside a pipeline')
 
 
@@ -98,6 +157,25 @@ class InputAndOutputTransformerMixin:
     """
     Base output transformer step that can modify data inputs, and expected_outputs at the same time.
     """
+
+    def handle_inverse_transform(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        """
+        Handle inverse transform by updating the data inputs, and expected outputs inside the data container.
+
+        :param context: execution context
+        :param data_container:
+        :return:
+        """
+        di_eo = (data_container.data_inputs, data_container.expected_outputs)
+        new_data_inputs, new_expected_outputs = self.inverse_transform(di_eo)
+
+        data_container.set_data_inputs(new_data_inputs)
+        data_container.set_expected_outputs(new_expected_outputs)
+
+        current_ids = self.hash(data_container)
+        data_container.set_current_ids(current_ids)
+
+        return data_container
 
     def handle_transform(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
         """
@@ -118,8 +196,7 @@ class InputAndOutputTransformerMixin:
 
         return data_container
 
-    def handle_fit_transform(self, data_container: DataContainer, context: ExecutionContext) -> (
-    'BaseStep', DataContainer):
+    def handle_fit_transform(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
         """
         Handle transform by fitting the step,
         and updating the data inputs, and expected outputs inside the data container.
@@ -138,3 +215,15 @@ class InputAndOutputTransformerMixin:
         data_container.set_current_ids(current_ids)
 
         return new_self, data_container
+
+    def fit(self, data_inputs, expected_outputs=None):
+        raise NotImplementedError('must be used inside a pipeline')
+
+    def fit_transform(self, data_inputs, expected_outputs=None):
+        raise NotImplementedError('must be used inside a pipeline')
+
+    def transform(self, data_inputs):
+        raise NotImplementedError('must be used inside a pipeline')
+
+    def inverse_transform(self, processed_outputs):
+        raise NotImplementedError('must be used inside a pipeline')

--- a/testing/steps/neuraxle_test_case.py
+++ b/testing/steps/neuraxle_test_case.py
@@ -1,0 +1,60 @@
+import numpy as np
+
+from neuraxle.base import ExecutionMode
+
+
+class NeuraxleTestCase:
+    def __init__(
+            self,
+            pipeline,
+            callbacks,
+            expected_callbacks_data,
+            hyperparams_space=None,
+            hyperparams=None,
+            expected_processed_outputs=None,
+            execution_mode=None,
+            more_arguments=None,
+            data_inputs=None,
+            expected_outputs=None
+    ):
+        self.expected_outputs = expected_outputs
+        self.data_inputs = data_inputs
+        self.execution_mode = execution_mode
+        self.pipeline = pipeline
+        self.callbacks = callbacks
+        self.expected_callbacks_data = expected_callbacks_data
+        self.hyperparams = hyperparams
+        self.hyperparams_space = hyperparams_space
+        self.expected_processed_outputs = expected_processed_outputs
+        self.more_arguments = more_arguments
+
+    def assert_callback_data_is_as_expected(self):
+        for callback, expected_callback_data in zip(self.callbacks, self.expected_callbacks_data):
+            if len(callback.data) > 0:
+                assert np.array_equal(
+                    np.array(callback.data),
+                    expected_callback_data
+                )
+            else:
+                assert np.array_equal(
+                    np.array([]),
+                    np.array(expected_callback_data)
+                )
+
+    def assert_expected_processed_outputs(self, processed_outputs):
+        if self.execution_mode != ExecutionMode.FIT:
+            assert np.array_equal(processed_outputs, self.expected_processed_outputs)
+
+    def execute(self):
+        for c in self.callbacks:
+            c.reset()
+
+        processed_outputs = None
+        if self.execution_mode == ExecutionMode.TRANSFORM:
+            processed_outputs = self.pipeline.transform(self.data_inputs)
+        if self.execution_mode == ExecutionMode.FIT_TRANSFORM:
+            self.pipeline, processed_outputs = self.pipeline.fit_transform(self.data_inputs, self.expected_outputs)
+        if self.execution_mode == ExecutionMode.FIT:
+            self.pipeline = self.pipeline.fit(self.data_inputs, self.expected_outputs)
+
+        return processed_outputs

--- a/testing/steps/test_reversible_preprocessing_wrapper.py
+++ b/testing/steps/test_reversible_preprocessing_wrapper.py
@@ -1,33 +1,86 @@
 import numpy as np
-from neuraxle.base import BaseStep, DataContainer, NonFittableMixin, ExecutionContext, ExecutionMode
+import pytest
+
+from neuraxle.base import ExecutionMode
+from neuraxle.pipeline import Pipeline
 from neuraxle.steps.flow import ReversiblePreprocessingWrapper
+from neuraxle.steps.misc import TapeCallbackFunction, CallbackWrapper
+from neuraxle.steps.numpy import MultiplyByN, AddN
+from testing.steps.neuraxle_test_case import NeuraxleTestCase
+
+DATA_INPUTS = np.array(range(5))
+EXPECTED_OUTPUTS = np.array(range(5, 10))
+EXPECTED_PROCESSED_OUTPUTS = np.array([5.0, 6.0, 7.0, 8.0, 9.0])
+
+tape_transform_preprocessing = TapeCallbackFunction()
+tape_fit_preprocessing = TapeCallbackFunction()
+tape_transform_postprocessing = TapeCallbackFunction()
+tape_fit_postprocessing = TapeCallbackFunction()
+tape_inverse_transform_preprocessing = TapeCallbackFunction()
 
 
-class MultiplyBy2(NonFittableMixin, BaseStep):
-    def transform(self, data_inputs):
-        return data_inputs * 2
-
-    def inverse_transform(self, processed_outputs):
-        return processed_outputs / 2
-
-
-class Add10(NonFittableMixin, BaseStep):
-    def transform(self, data_inputs):
-        return data_inputs + 10
-
-    def inverse_transform(self, processed_outputs):
-        return processed_outputs - 10
-
-
-def test_reversible_preprocessing_wrapper():
-    step = ReversiblePreprocessingWrapper(
-        preprocessing_step=MultiplyBy2(),
-        postprocessing_step=Add10()
+@pytest.mark.parametrize('test_case', [
+    NeuraxleTestCase(
+        pipeline=Pipeline([
+            ReversiblePreprocessingWrapper(
+                preprocessing_step=CallbackWrapper(MultiplyByN(2), tape_transform_preprocessing, tape_fit_postprocessing, tape_inverse_transform_preprocessing),
+                postprocessing_step=CallbackWrapper(AddN(10), tape_transform_postprocessing, tape_fit_postprocessing)
+            )]
+        ),
+        callbacks=[tape_transform_preprocessing, tape_fit_preprocessing, tape_transform_postprocessing, tape_fit_postprocessing, tape_inverse_transform_preprocessing],
+        expected_callbacks_data=[
+            [DATA_INPUTS],
+            [],
+            [DATA_INPUTS * 2],
+            [],
+            [(DATA_INPUTS * 2) + 10]
+        ],
+        data_inputs=DATA_INPUTS,
+        expected_processed_outputs=EXPECTED_PROCESSED_OUTPUTS,
+        execution_mode=ExecutionMode.TRANSFORM
+    ),
+    NeuraxleTestCase(
+        pipeline=Pipeline([
+            ReversiblePreprocessingWrapper(
+                preprocessing_step=CallbackWrapper(MultiplyByN(2), tape_transform_preprocessing, tape_fit_preprocessing, tape_inverse_transform_preprocessing),
+                postprocessing_step=CallbackWrapper(AddN(10), tape_transform_postprocessing, tape_fit_postprocessing)
+            )]
+        ),
+        callbacks=[tape_transform_preprocessing, tape_fit_preprocessing, tape_transform_postprocessing, tape_fit_postprocessing, tape_inverse_transform_preprocessing],
+        expected_callbacks_data=[
+            [DATA_INPUTS],
+            [(DATA_INPUTS, EXPECTED_OUTPUTS)],
+            [DATA_INPUTS * 2],
+            [(DATA_INPUTS * 2, EXPECTED_OUTPUTS)],
+            [(DATA_INPUTS * 2) + 10]
+        ],
+        data_inputs=DATA_INPUTS,
+        expected_outputs=EXPECTED_OUTPUTS,
+        expected_processed_outputs=EXPECTED_PROCESSED_OUTPUTS,
+        execution_mode=ExecutionMode.FIT_TRANSFORM
+    ),
+    NeuraxleTestCase(
+        pipeline=Pipeline([
+            ReversiblePreprocessingWrapper(
+                preprocessing_step=CallbackWrapper(MultiplyByN(2), tape_transform_preprocessing, tape_fit_preprocessing, tape_inverse_transform_preprocessing),
+                postprocessing_step=CallbackWrapper(AddN(10), tape_transform_postprocessing, tape_fit_postprocessing)
+            )]
+        ),
+        callbacks=[tape_transform_preprocessing, tape_fit_preprocessing, tape_transform_postprocessing, tape_fit_postprocessing, tape_inverse_transform_preprocessing],
+        expected_callbacks_data=[
+            [DATA_INPUTS],
+            [(DATA_INPUTS, EXPECTED_OUTPUTS)],
+            [],
+            [(DATA_INPUTS * 2, EXPECTED_OUTPUTS)],
+            []
+        ],
+        data_inputs=DATA_INPUTS,
+        expected_outputs=EXPECTED_OUTPUTS,
+        execution_mode=ExecutionMode.FIT
     )
+])
+def test_reversible_preprocessing_wrapper(test_case):
+    processed_outputs = test_case.execute()
 
-    outputs = step.handle_transform(
-        DataContainer(current_ids=range(5), data_inputs=np.array(range(5)), expected_outputs=None),
-        ExecutionContext.create_from_root(step, ExecutionMode.TRANSFORM, '/')
-    )
-
-    assert np.array_equal(outputs.data_inputs, np.array([5.0, 6.0, 7.0, 8.0, 9.0]))
+    test_case.assert_expected_processed_outputs(processed_outputs)
+    test_case.assert_callback_data_is_as_expected()

--- a/testing/steps/test_reversible_preprocessing_wrapper.py
+++ b/testing/steps/test_reversible_preprocessing_wrapper.py
@@ -1,0 +1,33 @@
+import numpy as np
+from neuraxle.base import BaseStep, DataContainer, NonFittableMixin, ExecutionContext, ExecutionMode
+from neuraxle.steps.flow import ReversiblePreprocessingWrapper
+
+
+class MultiplyBy2(NonFittableMixin, BaseStep):
+    def transform(self, data_inputs):
+        return data_inputs * 2
+
+    def inverse_transform(self, processed_outputs):
+        return processed_outputs / 2
+
+
+class Add10(NonFittableMixin, BaseStep):
+    def transform(self, data_inputs):
+        return data_inputs + 10
+
+    def inverse_transform(self, processed_outputs):
+        return processed_outputs - 10
+
+
+def test_reversible_preprocessing_wrapper():
+    step = ReversiblePreprocessingWrapper(
+        preprocessing_step=MultiplyBy2(),
+        postprocessing_step=Add10()
+    )
+
+    outputs = step.handle_transform(
+        DataContainer(current_ids=range(5), data_inputs=np.array(range(5)), expected_outputs=None),
+        ExecutionContext.create_from_root(step, ExecutionMode.TRANSFORM, '/')
+    )
+
+    assert np.array_equal(outputs.data_inputs, np.array([5.0, 6.0, 7.0, 8.0, 9.0]))


### PR DESCRIPTION
1. ReversiblePreprocessingWrapper : TruncableSteps with a preprocessing step(1), and a postprocessing step(2)
that inverse transforms with the preprocessing step at the end (1, 2, reversed(1)).
```
         step = ReversiblePreprocessingWrapper(
            preprocessing_step=MultiplyBy2(),
            postprocessing_step=Add10()
        )

        outputs = step.transform(np.array(range(5)))

        assert np.array_equal(outputs, np.array([5, 6, 7, 8, 9]))
```
 
2. AddN: Step to add a scalar to a numpy array.
Accepts an integer for the number to add to every data inputs.

```
        pipeline = Pipeline([
            AddN(1)
        ])
        outputs = pipeline.transform(np.array([1])
        # outputs => np.array([2])
```

3. Added handle_inverse_transform in BaseStep, and MetaStepMixin.
4. Added a CallbackWrapper for better unit testing. 
5. Added NeuraxleTestCase for better unit testing. 

