### PR TITLE
Saver parallel transform Wip

### DIFF
--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -340,20 +340,28 @@ class ExecutionContext:
     def get_execution_mode(self) -> ExecutionMode:
         return self.execution_mode
 
-    def save_all_unsaved(self):
+    def save(self, full_dump=False):
         """
         Save all unsaved steps in the parents of the execution context using :func:`~neuraxle.base.BaseStep.save`.
         This method is called from a step checkpointer inside a :class:`Checkpoint`.
 
+        :param full_dump: save full pipeline dump to be able to load everything without source code (false by default).
+        :type full_dump: bool
         :return:
+
+        .. seealso::
+            :class:`BaseStep`,
+            :func:`~neuraxle.base.BaseStep.save`
         """
         while not self.empty():
             should_save_last_step = self.should_save_last_step()
             last_step = self.peek()
+            if full_dump:
+                should_save_last_step = True
 
             self.pop()
             if should_save_last_step:
-                last_step.save(self)
+                last_step.save(self, full_dump)
 
     def should_save_last_step(self) -> bool:
         """

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -421,17 +421,15 @@ class ExecutionContext:
     def get_execution_mode(self) -> ExecutionMode:
         return self.execution_mode
 
-    def save_all_unsaved(self, full_dump=False):
+    def save_all_unsaved(self):
         """
         Save all unsaved steps in the parents of the execution context using :func:`~neuraxle.base.BaseStep.save`.
         This method is called from a step checkpointer inside a :class:`Checkpoint`.
 
-        :param full_dump: full dump of the step or not
-        :type full_dump: bool
         :return:
         """
         while not self.empty():
-            should_save_last_step = full_dump or self.should_save_last_step()
+            should_save_last_step = self.should_save_last_step()
             last_step = self.peek()
 
             self.pop()

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -483,8 +483,10 @@ class ExecutionContext:
             :class:`Identity`
         """
         context_for_loading = self
+        context_for_loading = context_for_loading.push(Identity(name=path))
+
         if os.sep in path:
-            context_for_loading = self.push(Identity(name=path, savers=[self.stripped_saver])).to_identity()
+            context_for_loading = context_for_loading.to_identity()
             path = path.split(os.sep)[-1]
 
         return FullDumpLoader(
@@ -514,6 +516,7 @@ class ExecutionContext:
         return ExecutionContext(
             root=self.root,
             execution_mode=self.execution_mode,
+            stripped_saver=self.stripped_saver,
             parents=parents
         )
 
@@ -2853,4 +2856,5 @@ class FullDumpLoader(Identity):
 
         loaded_self = context.stripped_saver.load_step(self, context)
 
+        context.pop()
         return loaded_self.load(context, full_dump)

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -447,6 +447,9 @@ class ExecutionContext:
         """
         return len(self) == 0
 
+    def load(self, name: str):
+        return FullDumpLoader(name).load(self, True)
+
     def __len__(self):
         return len(self.parents)
 
@@ -1276,9 +1279,8 @@ class BaseStep(ABC):
             :class:`BaseSaver`
         """
         context = context.push(self)
-        savers = [context.stripped_saver] + self.savers if not full_dump else \
-            self.savers
 
+        savers = [context.stripped_saver] + self.savers
         return self._load_step(context, savers)
 
     def _load_step(self, context, savers):
@@ -2774,6 +2776,5 @@ class FullDumpLoader(Identity):
             raise Exception('Cannot Load Full Dump For Step {}'.format(os.path.join(context.get_path(), self.name)))
 
         loaded_self = context.stripped_saver.load_step(self, context.push(self))
-        self.set_savers(loaded_self.savers)
 
         return loaded_self.load(context, full_dump)

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -1930,19 +1930,13 @@ class ForceAlwaysHandleMixin:
         raise NotImplementedError('Must implement handle_fit_transform in {0}'.format(self.name))
 
     def transform(self, data_inputs) -> 'ForceAlwaysHandleMixin':
-        raise Exception(
-            'Transform method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_transform instead.'.format(
-                self.name))
+        raise Exception('Transform method is not supported for {0}, because it inherits from ForceAlwaysHandleMixin. Please use handle_transform instead.'.format(self.name))
 
     def fit(self, data_inputs, expected_outputs=None) -> 'ForceAlwaysHandleMixin':
-        raise Exception(
-            'Fit method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_fit instead.'.format(
-                self.name))
+        raise Exception('Fit method is not supported for {0}, because it inherits from ForceAlwaysHandleMixin. Please use handle_fit instead.'.format(self.name))
 
     def fit_transform(self, data_inputs, expected_outputs=None) -> 'ForceAlwaysHandleMixin':
-        raise Exception(
-            'Fit transform method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_fit_transform instead.'.format(
-                self.name))
+        raise Exception('Fit transform method is not supported for {0}, because it inherits from ForceAlwaysHandleMixin. Please use handle_fit_transform instead.'.format(self.name))
 
 
 class NonFittableMixin:

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -2842,12 +2842,30 @@ class Identity(NonTransformableMixin, NonFittableMixin, BaseStep):
 
 
 class FullDumpLoader(Identity):
+    """
+    Identity step that can load the full dump of a pipeline step.
+    Used by :func:`~neuraxle.base.BaseStep.load`.
+
+    .. seealso::
+        :class:`ExecutionContext`
+        :class:`BaseStep`,
+        :class:`Identity`
+    """
     def __init__(self, name, stripped_saver=None):
         if stripped_saver is None:
             stripped_saver = JoblibStepSaver()
         Identity.__init__(self, name=name, savers=[stripped_saver])
 
     def load(self, context: ExecutionContext, full_dump=True) -> BaseStep:
+        """
+        Load the full dump of a pipeline step.
+
+        :param context: execution context
+        :param full_dump: load full dump or not (always true, inherited from :class:`BaseStep`
+        :type full_dump: load full dump or not
+        :return: loaded step
+        :rtype: BaseStep
+        """
         if not context.stripped_saver.can_load(self, context):
             raise Exception('Cannot Load Full Dump For Step {}'.format(os.path.join(context.get_path(), self.name)))
 

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -363,6 +363,17 @@ class ExecutionContext:
             if should_save_last_step:
                 last_step.save(self, full_dump)
 
+    def save_last(self):
+        """
+        Save only the last step in the execution context.
+
+        .. seealso::
+            :func:`~neuraxle.base.ExecutionContext.save`
+        """
+        last_step = self.peek()
+        self.pop()
+        last_step.save(self, True)
+
     def should_save_last_step(self) -> bool:
         """
         Returns True if the last step should be saved.
@@ -427,14 +438,17 @@ class ExecutionContext:
         if not os.path.exists(path):
             os.makedirs(path)
 
-    def get_path(self):
+    def get_path(self, with_root=True):
         """
         Creates the directory path for the current execution context.
 
         :return: current context path
         :rtype: str
         """
-        parents_with_path = [self.root] + [p.name for p in self.parents]
+        parents_with_path = [self.root] if with_root else []
+        parents_with_path += [p.name for p in self.parents]
+        if len(parents_with_path) == 0:
+            return '/'
         return os.path.join(*parents_with_path)
 
     def get_names(self):
@@ -455,8 +469,53 @@ class ExecutionContext:
         """
         return len(self) == 0
 
-    def load(self, name: str):
-        return FullDumpLoader(name).load(self, True)
+    def load(self, path: str) -> 'BaseStep':
+        """
+        Load full dump at the given path.
+
+        :param path: pipeline step path
+        :type path: str
+        :return: loaded step
+        :rtype: BaseStep
+
+        .. seealso::
+            :class:`FullDumpLoader`,
+            :class:`Identity`
+        """
+        context_for_loading = self
+        if os.sep in path:
+            context_for_loading = self.push(Identity(name=path, savers=[self.stripped_saver])).to_identity()
+            path = path.split(os.sep)[-1]
+
+        return FullDumpLoader(
+            name=path,
+            stripped_saver=self.stripped_saver
+        ).load(context_for_loading, True)
+
+    def to_identity(self) -> 'ExecutionContext':
+        """
+        Create a fake execution context containing only identity steps.
+        Create the parents by using the path of the current execution context.
+
+        :return: fake identity execution context
+        :rtype: ExecutionContext
+
+        .. seealso::
+            :class:`FullDumpLoader`,
+            :class:`Identity`
+        """
+        step_names = self.get_path(False).split(os.sep)
+
+        parents = [
+            Identity(name=name, savers=[self.stripped_saver])
+            for name in step_names
+        ]
+
+        return ExecutionContext(
+            root=self.root,
+            execution_mode=self.execution_mode,
+            parents=parents
+        )
 
     def __len__(self):
         return len(self.parents)
@@ -2789,9 +2848,6 @@ class FullDumpLoader(Identity):
         Identity.__init__(self, name=name, savers=[stripped_saver])
 
     def load(self, context: ExecutionContext, full_dump=True) -> BaseStep:
-        if os.sep not in context.get_path():
-            context = context.push(self)
-
         if not context.stripped_saver.can_load(self, context):
             raise Exception('Cannot Load Full Dump For Step {}'.format(os.path.join(context.get_path(), self.name)))
 

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -177,6 +177,8 @@ class BaseSaver(ABC):
         :type step: BaseStep
         :param context: execution context
         :type context: ExecutionContext
+        :param save_savers:
+        :type save_savers: bool
         :return:
         """
         raise NotImplementedError()
@@ -206,7 +208,17 @@ class BaseSaver(ABC):
         raise NotImplementedError()
 
 
-class JoblibStepSaver(BaseSaver):
+class FullDumpSaverMixin:
+    @abstractmethod
+    def save_step_savers(self, step, context) -> 'BaseStep':
+        raise NotImplementedError()
+
+    @abstractmethod
+    def load_step_savers(self, step, context) -> List[BaseSaver]:
+        raise NotImplementedError()
+
+
+class JoblibStepSaver(FullDumpSaverMixin, BaseSaver):
     """
     Saver that can save, or load a step with `joblib.load <https://joblib.readthedocs.io/en/latest/generated/joblib.load.html>`_,
     and `joblib.dump <https://joblib.readthedocs.io/en/latest/generated/joblib.dump.html>`_.
@@ -251,6 +263,19 @@ class JoblibStepSaver(BaseSaver):
         """
         return os.path.join(context.get_path(), '{0}.joblib'.format(step.name))
 
+    def _create_step_savers_path(self, context, step):
+        """
+        Create step savers path for the given context.
+
+        :param context: execution context
+        :type context: ExecutionContext
+        :param step: step to save, or load
+        :type step: BaseStep
+        :return: path
+        :rtype: str
+        """
+        return os.path.join(context.get_path(), '{0}_savers.joblib'.format(step.name))
+
     def save_step(self, step: 'BaseStep', context: 'ExecutionContext') -> 'BaseStep':
         """
         Saved step stripped out of things that would make it unserializable.
@@ -268,6 +293,18 @@ class JoblibStepSaver(BaseSaver):
 
         return step
 
+    def save_step_savers(self, step, context) -> 'BaseStep':
+        context.mkdir()
+
+        step_savers_path = self._create_step_savers_path(context, step)
+        dump(step.savers, step_savers_path)
+
+        return step
+
+    def load_step_savers(self, step, context) -> List[BaseSaver]:
+        context.mkdir()
+        return load(self._create_step_savers_path(context, step))
+
     def load_step(self, step: 'BaseStep', context: 'ExecutionContext') -> 'BaseStep':
         """
         Load stripped step.
@@ -282,8 +319,11 @@ class JoblibStepSaver(BaseSaver):
 
         # we need to keep the current steps in memory because they have been deleted before saving...
         # the steps that have not been saved yet need to be in memory while loading a truncable steps...
-        if isinstance(step, TruncableSteps):
-            loaded_step.steps = step.steps
+        if isinstance(loaded_step, TruncableSteps):
+            loaded_step.steps = [
+                Identity(savers=sub_step_savers).set_name(sub_step_name)
+                for sub_step_name, sub_step_savers in loaded_step.sub_steps_savers
+            ]
 
         return loaded_step
 
@@ -335,15 +375,17 @@ class ExecutionContext:
     def get_execution_mode(self) -> ExecutionMode:
         return self.execution_mode
 
-    def save_all_unsaved(self):
+    def save_all_unsaved(self, full_dump=False):
         """
         Save all unsaved steps in the parents of the execution context using :func:`~neuraxle.base.BaseStep.save`.
         This method is called from a step checkpointer inside a :class:`Checkpoint`.
 
+        :param full_dump: full dump of the step or not
+        :type full_dump: bool
         :return:
         """
         while not self.empty():
-            should_save_last_step = self.should_save_last_step()
+            should_save_last_step = full_dump or self.should_save_last_step()
             last_step = self.peek()
 
             self.pop()
@@ -597,6 +639,15 @@ class BaseStep(ABC):
         :rtype: BaseStep
         """
         self.is_initialized = True
+        return self
+
+    def invalidate(self) -> 'BaseStep':
+        """
+        Invalidate step for saving.
+
+        :return: self
+        :rtype: BaseStep
+        """
         self.is_invalidated = True
         return self
 
@@ -904,7 +955,8 @@ class BaseStep(ABC):
 
         return new_self, data_container
 
-    def handle_fit_transform(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
+    def handle_fit_transform(self, data_container: DataContainer, context: ExecutionContext) -> (
+            'BaseStep', DataContainer):
         """
         Override this to add side effects or change the execution flow before (or after) calling * :func:`~neuraxle.base.BaseStep.fit_transform`.
         The default behavior is to rehash current ids with the step hyperparameters.
@@ -965,7 +1017,8 @@ class BaseStep(ABC):
         """
         return data_container
 
-    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
+    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (
+            'BaseStep', DataContainer):
         """
         Fit data container.
 
@@ -977,7 +1030,8 @@ class BaseStep(ABC):
         new_self = self.fit(data_container.data_inputs, data_container.expected_outputs)
         return new_self, data_container
 
-    def _will_fit_transform(self, data_container: DataContainer, context: ExecutionContext) -> (DataContainer, ExecutionContext):
+    def _will_fit_transform(self, data_container: DataContainer, context: ExecutionContext) -> (
+            DataContainer, ExecutionContext):
         """
         Apply side effects before fit_transform is called.
 
@@ -1000,7 +1054,8 @@ class BaseStep(ABC):
         """
         return data_container
 
-    def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
+    def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (
+            'BaseStep', DataContainer):
         """
         Fit transform data container.
 
@@ -1014,7 +1069,8 @@ class BaseStep(ABC):
 
         return new_self, data_container
 
-    def _will_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
+    def _will_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (
+            'BaseStep', DataContainer):
         """
         Apply side effects before transform.
 
@@ -1194,7 +1250,7 @@ class BaseStep(ABC):
         """
         return self.is_invalidated and self.is_initialized
 
-    def save(self, context: ExecutionContext) -> 'BaseStep':
+    def save(self, context: ExecutionContext, full_dump=False) -> 'BaseStep':
         """
         Save step using the execution context to create the directory to save the step into.
         The saving happens by looping through all of the step savers in the reversed order.
@@ -1205,6 +1261,8 @@ class BaseStep(ABC):
 
         :param context: context to save from
         :type context: ExecutionContext
+        :param full_dump: save full dump bool
+        :type full_dump: bool
         :return: self
         :rtype: BaseStep
 
@@ -1213,32 +1271,45 @@ class BaseStep(ABC):
             :class:`BaseSaver`
         """
         context = context.push(self)
+        self.is_invalidated = False
 
-        if self.is_invalidated and self.is_initialized:
-            self.is_invalidated = False
+        if full_dump:
+            self.apply_method(lambda step: step.setup() if not step.is_initialized else None)
+            self.apply_method(lambda step: step.invalidate())
+            self._save_step_savers(context)
 
-            context.mkdir()
-            stripped_step = copy(self)
+        return self._save_step(context)
 
-            # A final "visitor" saver will save anything that
-            # wasn't saved customly after stripping the rest.
-            savers_with_provided_default_stripped_saver = [context.stripped_saver] + self.savers
+    def _save_step_savers(self, context):
+        for saver in self.savers:
+            if isinstance(saver, FullDumpSaverMixin):
+                return saver.save_step_savers(self, context)
 
-            for saver in reversed(savers_with_provided_default_stripped_saver):
-                # Each saver strips the step a bit more if needs be.
-                stripped_step = saver.save_step(stripped_step, context)
+        raise Exception('Cannot Save Full Dump Properly. {} does not have any saver that inherit from FullDumpSaverMixin.'.format(self.name))
 
-            return stripped_step
+    def _save_step(self, context):
+        context.mkdir()
+        stripped_step = copy(self)
 
-        return self
+        # A final "visitor" saver will save anything that
+        # wasn't saved customly after stripping the rest.
+        savers_with_provided_default_stripped_saver = [context.stripped_saver] + self.savers
 
-    def load(self, context: ExecutionContext) -> 'BaseStep':
+        for saver in reversed(savers_with_provided_default_stripped_saver):
+            # Each saver strips the step a bit more if needs be.
+            stripped_step = saver.save_step(stripped_step, context)
+
+        return stripped_step
+
+    def load(self, context: ExecutionContext, full_dump=False) -> 'BaseStep':
         """
         Load step using the execution context to create the directory of the saved step.
         Warning:
 
         :param context: execution context to load step from
-        :return:
+        :param full_dump: save full dump bool
+        :type full_dump: bool
+        :return: loaded step
 
         .. warning::
             Please do not override this method because on loading it is an identity
@@ -1249,10 +1320,21 @@ class BaseStep(ABC):
             :class:`BaseSaver`
         """
         context = context.push(self)
+        if full_dump:
+            self.set_savers(self._load_step_savers(context))
 
+        return self._load_step(context)
+
+    def _load_step_savers(self, context):
+        for saver in self.savers:
+            if isinstance(saver, FullDumpSaverMixin):
+                return saver.load_step_savers(self, context)
+
+        raise Exception('Cannot Load Full Dump Properly. {} does not have any saver that inherit from FullDumpSaverMixin.'.format(self.name))
+
+    def _load_step(self, context):
         # A final "visitor" saver might reload anything that wasn't saved customly after stripping the rest.
         savers_with_provided_default_stripped_saver = [context.stripped_saver] + self.savers
-
         loaded_self = self
         for saver in savers_with_provided_default_stripped_saver:
             # Each saver unstrips the step a bit more if needed
@@ -1264,7 +1346,6 @@ class BaseStep(ABC):
                                                                                  self.__class__.__name__,
                                                                                  saver.__class__.__name__))
                 break
-
         return loaded_self
 
     def meta_fit(self, X_train, y_train, metastep: 'MetaStepMixin'):
@@ -1791,13 +1872,19 @@ class ForceAlwaysHandleMixin:
         raise NotImplementedError('Must implement handle_fit_transform in {0}'.format(self.name))
 
     def transform(self, data_inputs) -> 'ForceAlwaysHandleMixin':
-        raise Exception('Transform method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_transform instead.'.format(self.name))
+        raise Exception(
+            'Transform method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_transform instead.'.format(
+                self.name))
 
     def fit(self, data_inputs, expected_outputs=None) -> 'ForceAlwaysHandleMixin':
-        raise Exception('Fit method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_fit instead.'.format(self.name))
+        raise Exception(
+            'Fit method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_fit instead.'.format(
+                self.name))
 
     def fit_transform(self, data_inputs, expected_outputs=None) -> 'ForceAlwaysHandleMixin':
-        raise Exception('Fit transform method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_fit_transform instead.'.format(self.name))
+        raise Exception(
+            'Fit transform method is not supported for {0}, because it inherits from ForceHandleMixin. Please use handle_fit_transform instead.'.format(
+                self.name))
 
 
 class NonFittableMixin:
@@ -1892,10 +1979,9 @@ class TruncableJoblibStepSaver(JoblibStepSaver):
         for i, (_, sub_step) in enumerate(step):
             if sub_step.should_save():
                 sub_steps_savers.append((step[i].name, step[i].get_savers()))
+                sub_step.save(context)
             else:
                 sub_steps_savers.append((step[i].name, None))
-
-            sub_step.save(context)
 
         step.sub_steps_savers = sub_steps_savers
 
@@ -2731,6 +2817,8 @@ class Identity(NonTransformableMixin, NonFittableMixin, BaseStep):
     """
 
     def __init__(self, savers=None, name=None):
+        if savers is None:
+            savers = [JoblibStepSaver()]
         NonTransformableMixin.__init__(self)
         NonFittableMixin.__init__(self)
         BaseStep.__init__(self, name=name, savers=savers)

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -284,11 +284,8 @@ class JoblibStepSaver(BaseSaver):
 
         # we need to keep the current steps in memory because they have been deleted before saving...
         # the steps that have not been saved yet need to be in memory while loading a truncable steps...
-        if isinstance(loaded_step, TruncableSteps):
-            loaded_step.set_steps([
-                (sub_step_name, Identity(savers=sub_step_savers).set_name(sub_step_name))
-                for sub_step_name, sub_step_savers in loaded_step.sub_steps_savers
-            ])
+        if isinstance(loaded_step, TruncableSteps) and hasattr(step, 'steps'):
+            loaded_step.steps = step.steps
 
         return loaded_step
 
@@ -509,7 +506,7 @@ class ExecutionContext:
         step_names = self.get_path(False).split(os.sep)
 
         parents = [
-            Identity(name=name, savers=[self.stripped_saver])
+            Identity(name=name)
             for name in step_names
         ]
 

--- a/neuraxle/checkpoints.py
+++ b/neuraxle/checkpoints.py
@@ -157,7 +157,7 @@ class StepSavingCheckpointer(BaseCheckpointer):
     ) -> DataContainer:
         if self.is_for_execution_mode(context.get_execution_mode()):
             # TODO: save the context by execution mode AND data container ids / summary
-            context.copy().save_all_unsaved()
+            context.copy().save()
 
         return data_container
 

--- a/neuraxle/parallel.py
+++ b/neuraxle/parallel.py
@@ -1,0 +1,104 @@
+"""
+Neuraxle steps for parallel processing
+================================================
+
+Neuraxle Steps for parallel processing
+
+..
+    Copyright 2019, Neuraxio Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+"""
+import os
+from abc import abstractmethod
+
+import numpy as np
+from joblib import Parallel, delayed
+
+from neuraxle.base import BaseStep, MetaStepMixin, NonFittableMixin, ExecutionContext, Identity
+from neuraxle.data_container import DataContainer
+
+
+
+class DispacherStep(BaseStep):
+    def __init__(self):
+        BaseStep.__init__(self)
+
+    def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext):
+        pass
+
+    @abstractmethod
+    def dispatch(self, data_container: DataContainer, context: ExecutionContext):
+        raise NotImplementedError()
+
+    def set_step_name(self, name: str):
+        self.name = name
+
+
+class SharedMemoryDispatcherStep(DispacherStep):
+    def dispatch(self, data_container: DataContainer, context: ExecutionContext):
+        data_inputs = np.array(data_container.data_inputs)
+        expected_outputs = np.array(data_container.expected_outputs)
+
+        shared_memory_data_inputs = shared_memory.SharedMemory(create=True, size=data_inputs.nbytes)
+        shared_memory_expected_outputs = shared_memory.SharedMemory(create=True, size=expected_outputs.npbytes)
+        shm_a = shared_memory.SharedMemory(create=True, size=10)
+
+        pass
+
+
+class MultiprocessingDispatcher(DispacherStep):
+    def dispatch(self, data_container: DataContainer, context: ExecutionContext):
+        return Parallel(n_jobs=-1)(
+            delayed(self.receive)(di, eo)
+            for di, eo in zip(context.get_path(), data_container.data_inputs, data_container.expected_outputs)
+        )
+
+    def receive(self, execution_context_path, data_inputs, expected_outputs=None):
+        step_names = execution_context_path.split(os.sep)
+
+        parents = [Identity(name) for name in step_names]
+        context = ExecutionContext(parents=parents)
+        step = context.load(self.name)
+
+        return step.transform(data_inputs, expected_outputs)
+
+
+class SaverParallelTransform(NonFittableMixin, MetaStepMixin, BaseStep):
+    """
+    Use savers to parallelize steps transformations to avoid python limitations when importing external librairies.
+    Dispatching technique class to abstract the workers.
+
+    .. seealso::
+        :func:`~NonFittableMixin`,
+        :func:`~MetaStepMixin`,
+        :class:`BaseStep`
+    """
+
+    def __init__(
+            self,
+            wrapped: BaseStep,
+            dispatcher: DispacherStep
+    ):
+        MetaStepMixin.__init__(self, wrapped)
+        BaseStep.__init__(self)
+
+        self.dispatcher = dispatcher
+        self.dispatcher.set_step_name(self.wrapped.name)
+
+    def _will_transform_data_container(self, data_container: DataContainer, context: ExecutionContext):
+        self.wrapped.save(context, full_dump=True)
+
+    def _transform_data_container(self, data_container, context):
+        data_container = self.dispatcher.handle_transform(data_container, context)

--- a/neuraxle/parallel.py
+++ b/neuraxle/parallel.py
@@ -21,61 +21,84 @@ Neuraxle Steps for parallel processing
 
 """
 import os
-from abc import abstractmethod
 
 import numpy as np
-from joblib import Parallel, delayed
+from fs.memoryfs import MemoryFS
+from joblib import dump, Parallel, delayed, load
 
-from neuraxle.base import BaseStep, MetaStepMixin, NonFittableMixin, ExecutionContext, Identity
+from neuraxle.base import BaseStep, MetaStepMixin, NonFittableMixin, ExecutionContext, Identity, BaseSaver, \
+    DEFAULT_CACHE_FOLDER, ExecutionMode
 from neuraxle.data_container import DataContainer
 
 
+class MemoryFSJoblibSaver(BaseSaver):
+    def __init__(self, memory_file_system):
+        self.memory_file_system = memory_file_system
 
-class DispacherStep(BaseStep):
-    def __init__(self):
-        BaseStep.__init__(self)
+    def save_step(self, step: 'BaseStep', context: 'ExecutionContext') -> 'BaseStep':
+        step_path = self._create_step_path(context, step)
 
-    def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext):
-        pass
+        self.memory_file_system.makedir(step_path)
 
-    @abstractmethod
-    def dispatch(self, data_container: DataContainer, context: ExecutionContext):
-        raise NotImplementedError()
+        with self.memory_file_system.open(step_path, 'w+') as file:
+            dump(file, step_path)
 
-    def set_step_name(self, name: str):
-        self.name = name
+        return step
 
+    def can_load(self, step: 'BaseStep', context: 'ExecutionContext'):
+        return self.memory_file_system.exists(self._create_step_path(context, step))
 
-class SharedMemoryDispatcherStep(DispacherStep):
-    def dispatch(self, data_container: DataContainer, context: ExecutionContext):
-        data_inputs = np.array(data_container.data_inputs)
-        expected_outputs = np.array(data_container.expected_outputs)
+    def load_step(self, step: 'BaseStep', context: 'ExecutionContext') -> 'BaseStep':
+        step_path = self._create_step_path(context, step)
 
-        shared_memory_data_inputs = shared_memory.SharedMemory(create=True, size=data_inputs.nbytes)
-        shared_memory_expected_outputs = shared_memory.SharedMemory(create=True, size=expected_outputs.npbytes)
-        shm_a = shared_memory.SharedMemory(create=True, size=10)
+        with self.memory_file_system.open(step_path, 'r') as file:
+            return load(file)
 
-        pass
+    def _create_step_path(self, context, step):
+        return os.path.join(context.get_path(), '{0}.joblib'.format(step.name))
 
+class MemoryFSExecutionContext(ExecutionContext):
+    def __init__(self,
+        memory_file_system: MemoryFS,
+        root: str = DEFAULT_CACHE_FOLDER,
+        execution_mode: ExecutionMode = None,
+        stripped_saver: BaseSaver = None,
+        parents=None
+    ):
+        ExecutionContext.__init__(
+            self,
+            root=root,
+            execution_mode=execution_mode,
+            stripped_saver=stripped_saver,
+            parents=parents
+        )
+        self.memory_file_system = memory_file_system
 
-class MultiprocessingDispatcher(DispacherStep):
-    def dispatch(self, data_container: DataContainer, context: ExecutionContext):
-        return Parallel(n_jobs=-1)(
-            delayed(self.receive)(di, eo)
-            for di, eo in zip(context.get_path(), data_container.data_inputs, data_container.expected_outputs)
+    def mkdir(self):
+        path = self.get_path()
+        parts = path.split(os.sep)
+
+        dir_to_create = ''
+        for i in range(len(parts)):
+            dir_to_create += parts[i] + os.sep
+            if not self.memory_file_system.exists(dir_to_create):
+                self.memory_file_system.makedir(dir_to_create)
+
+    def push(self, step: 'BaseStep'):
+        return MemoryFSExecutionContext(
+            memory_file_system=self.memory_file_system,
+            root=self.root,
+            execution_mode=self.execution_mode,
+            parents=self.parents + [step],
+            stripped_saver=self.stripped_saver
         )
 
-    def receive(self, execution_context_path, data_inputs, expected_outputs=None):
-        step_names = execution_context_path.split(os.sep)
-
-        parents = [Identity(name) for name in step_names]
-        context = ExecutionContext(parents=parents)
-        step = context.load(self.name)
-
-        return step.transform(data_inputs, expected_outputs)
+    def get_path(self):
+        parents_with_path = [p.name for p in self.parents]
+        return os.path.join(*parents_with_path)
 
 
-class SaverParallelTransform(NonFittableMixin, MetaStepMixin, BaseStep):
+class SaverParallelTransform(NonFittableMixin, BaseStep):
     """
     Use savers to parallelize steps transformations to avoid python limitations when importing external librairies.
     Dispatching technique class to abstract the workers.
@@ -85,20 +108,61 @@ class SaverParallelTransform(NonFittableMixin, MetaStepMixin, BaseStep):
         :func:`~MetaStepMixin`,
         :class:`BaseStep`
     """
-
-    def __init__(
-            self,
-            wrapped: BaseStep,
-            dispatcher: DispacherStep
-    ):
+    def __init__(self, wrapped: BaseStep, n_jobs: int = None):
         MetaStepMixin.__init__(self, wrapped)
         BaseStep.__init__(self)
+        self.n_jobs = n_jobs
 
-        self.dispatcher = dispatcher
-        self.dispatcher.set_step_name(self.wrapped.name)
+    def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext):
+        with MemoryFS() as memory_file_system:
+            shared_memory_execution_context = MemoryFSExecutionContext(
+                memory_file_system=memory_file_system,
+                root=memory_file_system.root,
+                parents=context.parents,
+                stripped_saver=MemoryFSJoblibSaver(memory_file_system)
+            )
+            # shared_memory_execution_context.save(full_dump=True)
+            execution_context_path = shared_memory_execution_context.get_path()
 
-    def _will_transform_data_container(self, data_container: DataContainer, context: ExecutionContext):
-        self.wrapped.save(context, full_dump=True)
+            # http://lagrange.univ-lyon1.fr/docs/numpy/1.11.0/reference/generated/numpy.memmap.html#numpy-memmap
+            # https://joblib.readthedocs.io/en/latest/auto_examples/parallel_memmap.html#sphx-glr-auto-examples-parallel-memmap-py
 
-    def _transform_data_container(self, data_container, context):
-        data_container = self.dispatcher.handle_transform(data_container, context)
+            with memory_file_system.open('data_inputs', 'w') as file:
+                memory_map_data_inputs = np.memmap(
+                    file,
+                    dtype=data_container.data_inputs.dtype,
+                    mode='w+',
+                    shape=data_container.data_inputs.shape
+                )
+                memory_map_data_inputs[:] = data_container.data_inputs[:]
+
+            with memory_file_system.open('expected_outputs', 'w') as file:
+                memory_map_expected_outputs = np.memmap(
+                    file,
+                    dtype=data_container.expected_outputs.dtype,
+                    mode='w+',
+                    shape=data_container.expected_outputs.shape
+                )
+                memory_map_expected_outputs[:] = data_container.expected_outputs[:]
+
+            # todo create a data container for each job, and create a summary id for each job
+
+            # todo loop through summary id for each jobs
+            outputs = Parallel(
+                n_jobs=-1,
+                backend='multiprocessing'
+            )(delayed(self.receive)(execution_context_path, data_container.copy()))
+
+        return data_container.set_data_inputs(outputs)
+
+    def transform(self, data_inputs):
+        raise Exception('Transform method not supported by SharedMemoryDispatcher. Please use this step inside a pipeline'.format(repr(self)))
+
+    def receive(self, execution_context_path, data_inputs, expected_outputs=None):
+        step_names = execution_context_path.split(os.sep)
+
+        parents = [Identity(name) for name in step_names]
+        context = ExecutionContext(parents=parents)
+        step = context.load(self.name)
+
+        return step.transform(data_inputs, expected_outputs)

--- a/neuraxle/parallel.py
+++ b/neuraxle/parallel.py
@@ -171,10 +171,21 @@ class MemoryFSExecutionContext(ExecutionContext):
         )
 
     def to_identity(self) -> 'MemoryFSExecutionContext':
+        """
+        Create a fake execution context containing only identity steps.
+        Create the parents by using the path of the current execution context.
+
+        :return: fake identity execution context
+        :rtype: MemoryFSExecutionContext
+
+        .. seealso::
+            :class:`FullDumpLoader`,
+            :class:`Identity`
+        """
         step_names = self.get_path(False).split(os.sep)
 
         parents = [
-            Identity(name=name, savers=[self.stripped_saver])
+            Identity(name=name)
             for name in step_names
         ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 setuptools
 pytest==4.3.1
 pytest-cov==2.6.1
-scikit-learn
-numpy
-scipy>=0.17
+numpy>=1.16.2
+scikit-learn>=0.20.3
 joblib>=0.13.2
 flask>=1.1.1
 flask-restful>=0.3.7
 conv==0.2
+fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 setuptools
 pytest==4.3.1
 pytest-cov==2.6.1
-numpy>=1.16.2
-scikit-learn>=0.20.3
+scikit-learn
+numpy
+scipy>=0.17
 joblib>=0.13.2
 flask>=1.1.1
 flask-restful>=0.3.7

--- a/testing/test_full_pipeline_dump.py
+++ b/testing/test_full_pipeline_dump.py
@@ -27,7 +27,7 @@ def test_integrated_should_save_and_load_full_pipeline_dump(tmpdir):
     pipeline.save(ExecutionContext(tmpdir), full_dump=True)
 
     # Then
-    loaded_pipeline = FullDumpLoader(PIPELINE_NAME).load(ExecutionContext(tmpdir))
+    loaded_pipeline = ExecutionContext(tmpdir).load(PIPELINE_NAME)
 
     assert isinstance(loaded_pipeline, Pipeline)
     assert isinstance(loaded_pipeline['step_a'], Identity)

--- a/testing/test_full_pipeline_dump.py
+++ b/testing/test_full_pipeline_dump.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from neuraxle.base import Identity, ExecutionContext, JoblibStepSaver
+from neuraxle.base import Identity, ExecutionContext, JoblibStepSaver, FullDumpLoader
 from neuraxle.pipeline import Pipeline
 from neuraxle.steps.misc import FitTransformCallbackStep, TapeCallbackFunction
 from neuraxle.steps.output_handlers import OutputTransformerWrapper
@@ -27,7 +27,7 @@ def test_integrated_should_save_and_load_full_pipeline_dump(tmpdir):
     pipeline.save(ExecutionContext(tmpdir), full_dump=True)
 
     # Then
-    loaded_pipeline = Identity().set_name(PIPELINE_NAME).load(ExecutionContext(tmpdir), full_dump=True)
+    loaded_pipeline = FullDumpLoader(PIPELINE_NAME).load(ExecutionContext(tmpdir))
 
     assert isinstance(loaded_pipeline, Pipeline)
     assert isinstance(loaded_pipeline['step_a'], Identity)

--- a/testing/test_full_pipeline_dump.py
+++ b/testing/test_full_pipeline_dump.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from neuraxle.base import Identity, ExecutionContext, JoblibStepSaver
+from neuraxle.pipeline import Pipeline
+from neuraxle.steps.misc import FitTransformCallbackStep, TapeCallbackFunction
+from neuraxle.steps.output_handlers import OutputTransformerWrapper
+
+PIPELINE_NAME = 'saved_pipeline'
+
+DATA_INPUTS = np.array(range(10))
+EXPECTED_OUTPUTS = np.array(range(10, 20))
+
+
+def test_integrated_should_save_and_load_full_pipeline_dump(tmpdir):
+    # Given
+    tape_fit_callback_function = TapeCallbackFunction()
+    tape_transform_callback_function = TapeCallbackFunction()
+    pipeline = Pipeline([
+        ('step_a', Identity()),
+        ('step_b', OutputTransformerWrapper(
+            FitTransformCallbackStep(tape_fit_callback_function, tape_transform_callback_function)
+        ))
+    ], cache_folder=tmpdir).set_name(PIPELINE_NAME)
+
+    # When
+    pipeline, outputs = pipeline.fit_transform(DATA_INPUTS, EXPECTED_OUTPUTS)
+    pipeline.save(ExecutionContext(tmpdir), full_dump=True)
+
+    # Then
+    loaded_pipeline = Identity().set_name(PIPELINE_NAME).load(ExecutionContext(tmpdir), full_dump=True)
+
+    assert isinstance(loaded_pipeline, Pipeline)
+    assert isinstance(loaded_pipeline['step_a'], Identity)
+    assert isinstance(loaded_pipeline['step_b'], OutputTransformerWrapper)
+
+    loaded_step_b_wrapped_step = loaded_pipeline['step_b'].wrapped
+    assert np.array_equal(loaded_step_b_wrapped_step.transform_callback_function.data[0], EXPECTED_OUTPUTS)
+    assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][0], EXPECTED_OUTPUTS)
+    assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][1], [None] * len(EXPECTED_OUTPUTS))

--- a/testing/test_full_pipeline_dump.py
+++ b/testing/test_full_pipeline_dump.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 
 from neuraxle.base import Identity, ExecutionContext, JoblibStepSaver, FullDumpLoader
@@ -11,7 +13,7 @@ DATA_INPUTS = np.array(range(10))
 EXPECTED_OUTPUTS = np.array(range(10, 20))
 
 
-def test_integrated_should_save_and_load_full_pipeline_dump(tmpdir):
+def test_load_full_dump_from_pipeline_name(tmpdir):
     # Given
     tape_fit_callback_function = TapeCallbackFunction()
     tape_transform_callback_function = TapeCallbackFunction()
@@ -34,6 +36,31 @@ def test_integrated_should_save_and_load_full_pipeline_dump(tmpdir):
     assert isinstance(loaded_pipeline['step_b'], OutputTransformerWrapper)
 
     loaded_step_b_wrapped_step = loaded_pipeline['step_b'].wrapped
+    assert np.array_equal(loaded_step_b_wrapped_step.transform_callback_function.data[0], EXPECTED_OUTPUTS)
+    assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][0], EXPECTED_OUTPUTS)
+    assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][1], [None] * len(EXPECTED_OUTPUTS))
+
+
+def test_load_full_dump_from_path(tmpdir):
+    # Given
+    tape_fit_callback_function = TapeCallbackFunction()
+    tape_transform_callback_function = TapeCallbackFunction()
+    pipeline = Pipeline([
+        ('step_a', Identity()),
+        ('step_b', OutputTransformerWrapper(
+            FitTransformCallbackStep(tape_fit_callback_function, tape_transform_callback_function)
+        ))
+    ], cache_folder=tmpdir).set_name(PIPELINE_NAME)
+
+    # When
+    pipeline, outputs = pipeline.fit_transform(DATA_INPUTS, EXPECTED_OUTPUTS)
+    pipeline.save(ExecutionContext(tmpdir), full_dump=True)
+
+    # Then
+    loaded_pipeline = ExecutionContext(tmpdir).load(os.path.join(PIPELINE_NAME, 'step_b'))
+
+    assert isinstance(loaded_pipeline, OutputTransformerWrapper)
+    loaded_step_b_wrapped_step = loaded_pipeline.wrapped
     assert np.array_equal(loaded_step_b_wrapped_step.transform_callback_function.data[0], EXPECTED_OUTPUTS)
     assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][0], EXPECTED_OUTPUTS)
     assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][1], [None] * len(EXPECTED_OUTPUTS))

--- a/testing/test_parallel.py
+++ b/testing/test_parallel.py
@@ -1,0 +1,27 @@
+import numpy as np
+from sklearn.datasets import load_boston
+from sklearn.decomposition import PCA
+from sklearn.model_selection import train_test_split
+from sklearn.utils import shuffle
+
+from neuraxle.hyperparams.distributions import RandInt
+from neuraxle.hyperparams.space import HyperparameterSpace
+from neuraxle.parallel import SaverParallelTransform
+from neuraxle.pipeline import Pipeline
+from neuraxle.steps.sklearn import SKLearnWrapper
+
+
+def test_saver_parallel_transform_should_parallelize():
+    boston = load_boston()
+    X, y = shuffle(boston.data, boston.target, random_state=13)
+    X = X.astype(np.float32)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, shuffle=False)
+
+
+    p = Pipeline([
+        SaverParallelTransform(
+            SKLearnWrapper(PCA(n_components=2), HyperparameterSpace({"n_components": RandInt(1, 3)}))
+        )
+    ])
+
+    outputs_train = p.transform(X_train)

--- a/testing/test_parallel.py
+++ b/testing/test_parallel.py
@@ -17,10 +17,11 @@ def test_saver_parallel_transform_should_parallelize():
     X = X.astype(np.float32)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, shuffle=False)
 
-
     p = Pipeline([
         SaverParallelTransform(
-            SKLearnWrapper(PCA(n_components=2), HyperparameterSpace({"n_components": RandInt(1, 3)}))
+            SKLearnWrapper(PCA(n_components=2), HyperparameterSpace({"n_components": RandInt(1, 3)})),
+            n_jobs=10,
+            batch_size=10
         )
     ])
 

--- a/testing/test_parallel.py
+++ b/testing/test_parallel.py
@@ -11,18 +11,23 @@ from neuraxle.pipeline import Pipeline
 from neuraxle.steps.sklearn import SKLearnWrapper
 
 
-def test_saver_parallel_transform_should_parallelize():
+def test_saver_parallel_transform(tmpdir):
     boston = load_boston()
     X, y = shuffle(boston.data, boston.target, random_state=13)
     X = X.astype(np.float32)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, shuffle=False)
+    sk_learn_pca = SKLearnWrapper(PCA(n_components=2), HyperparameterSpace({"n_components": RandInt(1, 3)}))
+    sk_learn_pca = sk_learn_pca.fit(X_train, y_train)
+    expected_outputs = sk_learn_pca.transform(X_train)
 
     p = Pipeline([
         SaverParallelTransform(
-            SKLearnWrapper(PCA(n_components=2), HyperparameterSpace({"n_components": RandInt(1, 3)})),
+            sk_learn_pca,
             n_jobs=10,
             batch_size=10
         )
-    ])
+    ], cache_folder=tmpdir)
 
-    outputs_train = p.transform(X_train)
+    actual_outputs = p.transform(X_train)
+
+    assert np.array_equal(expected_outputs, actual_outputs)

--- a/testing/test_pickle_checkpoint_step.py
+++ b/testing/test_pickle_checkpoint_step.py
@@ -23,7 +23,6 @@ import os
 import pickle
 
 import numpy as np
-from py.path import LocalPath
 
 from neuraxle.base import ExecutionContext, Identity
 from neuraxle.base import NonFittableMixin
@@ -72,7 +71,7 @@ def create_pipeline(tmpdir, pickle_checkpoint_step, tape, hyperparameters=None, 
     return pipeline
 
 
-def test_when_no_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
+def test_when_no_hyperparams_should_save_checkpoint_pickle(tmpdir):
     tape = TapeCallbackFunction()
     pickle_checkpoint_step = DefaultCheckpoint()
     pipeline = create_pipeline(tmpdir, pickle_checkpoint_step, tape)
@@ -88,7 +87,7 @@ def test_when_no_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
     assert os.path.exists(os.path.join(tmpdir, 'ResumablePipeline', 'pickle_checkpoint', 'eo', '1.pickle'))
 
 
-def test_when_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
+def test_when_hyperparams_should_save_checkpoint_pickle(tmpdir):
     tape = TapeCallbackFunction()
     pickle_checkpoint_step = DefaultCheckpoint()
     pipeline = create_pipeline(tmpdir, pickle_checkpoint_step, tape, HyperparameterSamples({"a__learning_rate": 1}))
@@ -109,7 +108,7 @@ def test_when_hyperparams_should_save_checkpoint_pickle(tmpdir: LocalPath):
         os.path.join(tmpdir, 'ResumablePipeline', 'pickle_checkpoint', 'eo', '898a67b2f5eeae6393ca4b3162ba8e3d.pickle'))
 
 
-def test_when_no_hyperparams_and_saved_same_pipeline_should_load_checkpoint_pickle(tmpdir: LocalPath):
+def test_when_no_hyperparams_and_saved_same_pipeline_should_load_checkpoint_pickle(tmpdir):
     # Given
     tape = TapeCallbackFunction()
 
@@ -134,7 +133,7 @@ def test_when_no_hyperparams_and_saved_same_pipeline_should_load_checkpoint_pick
     assert actual_tape == EXPECTED_TAPE_AFTER_CHECKPOINT
 
 
-def test_when_hyperparams_and_saved_same_pipeline_should_load_checkpoint_pickle(tmpdir: LocalPath):
+def test_when_hyperparams_and_saved_same_pipeline_should_load_checkpoint_pickle(tmpdir):
     # Given
     tape = TapeCallbackFunction()
 
@@ -161,7 +160,7 @@ def test_when_hyperparams_and_saved_same_pipeline_should_load_checkpoint_pickle(
     assert actual_tape == EXPECTED_TAPE_AFTER_CHECKPOINT
 
 
-def test_when_hyperparams_and_saved_no_pipeline_should_not_load_checkpoint_pickle(tmpdir: LocalPath):
+def test_when_hyperparams_and_saved_no_pipeline_should_not_load_checkpoint_pickle(tmpdir):
     # Given
     tape = TapeCallbackFunction()
     pickle_checkpoint_step = DefaultCheckpoint()
@@ -196,7 +195,7 @@ def setup_pickle_checkpoint(current_id, data_input, expected_output, pickle_chec
         pickle.dump((current_id, data_input, expected_output), file)
 
 
-def test_pickle_checkpoint_step_should_load_data_container(tmpdir: LocalPath):
+def test_pickle_checkpoint_step_should_load_data_container(tmpdir):
     initial_data_inputs = [1, 2]
     initial_expected_outputs = [2, 3]
 

--- a/testing/test_pickle_checkpoint_step.py
+++ b/testing/test_pickle_checkpoint_step.py
@@ -23,7 +23,7 @@ import os
 import pickle
 
 import numpy as np
-from py._path.local import LocalPath
+from py.path import LocalPath
 
 from neuraxle.base import ExecutionContext, Identity
 from neuraxle.base import NonFittableMixin


### PR DESCRIPTION
Use savers to parallelize steps transformations to avoid python limitations when importing external librairies. A ram disk should drastically improve the performance of parallel processing inside a neuraxle pipeline. 

I am still looking for a way to use a Ram Disk on different processes, but the abstractions should remain. 

```python
p = Pipeline([
      SaverParallelTransform(
         SKLearnWrapper(PCA(n_components=2), HyperparameterSpace({"n_components": RandInt(1, 3)})),
         n_jobs=10,
         batch_size=10
      )
], cache_folder=tmpdir)
```

@guillaume-chevalier looking for some feedback about the current design