### PR TITLE
Implement QueuedPipeline For Streaming WIP

### DIFF
--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -1836,6 +1836,7 @@ class NonFittableMixin:
     """
 
     def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext):
+        data_container, context = self._will_transform_data_container(data_container, context)
         return self, self._transform_data_container(data_container, context)
 
     def fit(self, data_inputs, expected_outputs=None) -> 'NonFittableMixin':

--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -24,6 +24,7 @@ Classes for containing the data that flows throught the pipeline steps.
 
 """
 import hashlib
+import math
 from typing import Any, Iterable, List
 
 from conv import convolved_1d
@@ -72,6 +73,7 @@ class DataContainer:
         :return:
         """
         self.data_inputs = data_inputs
+        return self
 
     def set_expected_outputs(self, expected_outputs: Iterable):
         """
@@ -82,6 +84,7 @@ class DataContainer:
         :return:
         """
         self.expected_outputs = expected_outputs
+        return self
 
     def set_current_ids(self, current_ids: List[str]):
         """
@@ -92,6 +95,7 @@ class DataContainer:
         :return:
         """
         self.current_ids = current_ids
+        return self
 
     def set_summary_id(self, summary_id: str):
         """
@@ -101,6 +105,7 @@ class DataContainer:
         :return:
         """
         self.summary_id = summary_id
+        return self
 
     def hash_summary(self):
         """
@@ -148,6 +153,9 @@ class DataContainer:
                 data_inputs=data_inputs,
                 expected_outputs=expected_outputs
             )
+
+    def get_n_batches(self, batch_size: int) -> int:
+        return math.ceil(len(self.data_inputs) / batch_size)
 
     def copy(self):
         return DataContainer(

--- a/neuraxle/distributed/streaming.py
+++ b/neuraxle/distributed/streaming.py
@@ -56,6 +56,9 @@ class Subject(Observer):
         self.on_next_fun = on_next_fun
         self.observable = Observable()
 
+    def subscribe(self, observer):
+        self.observable = self.observable.subscribe(observer)
+
     def on_next(self, value):
         if self.on_next_fun is not None:
             value = self.on_next_fun(value)
@@ -297,7 +300,7 @@ class BaseQueuedPipeline(NonFittableMixin, CustomPipelineMixin, Pipeline):
 
         return name, n_workers, max_size, actual_step
 
-    def _will_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
+    def _will_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (DataContainer, ExecutionContext):
         """
         Start the :class:`QueueWorker` for each step before transforming the data container.
 
@@ -310,6 +313,8 @@ class BaseQueuedPipeline(NonFittableMixin, CustomPipelineMixin, Pipeline):
         self.connect_queue_workers()
         for i, (name, step) in enumerate(self):
             step.start(context)
+
+        return data_container, context
 
     def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
         """

--- a/neuraxle/distributed/streaming.py
+++ b/neuraxle/distributed/streaming.py
@@ -1,0 +1,372 @@
+"""
+Neuraxle steps for streaming data in parallel in the pipeline
+===================================================================
+
+Neuraxle steps for streaming data in parallel in the pipeline
+
+..
+    Copyright 2019, Neuraxio Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+"""
+from abc import abstractmethod
+from multiprocessing import Queue, Lock
+from multiprocessing.context import Process
+from threading import Thread
+from typing import Tuple, List, Union
+
+from neuraxle.base import NamedTupleList, ExecutionContext, BaseStep, MetaStepMixin
+from neuraxle.data_container import DataContainer, ListDataContainer
+from neuraxle.pipeline import Pipeline, CustomPipelineMixin
+
+
+class Observer:
+    """
+    Observer class that listens to :class:`Observable` events.
+
+    .. seealso::
+        :class:`Observable`
+    """
+
+    @abstractmethod
+    def on_next(self, value):
+        """
+        Method called by the observables to notifiy the observers.
+
+        :param value:
+        :return:
+        """
+        pass
+
+
+class Observable:
+    """
+    Observable class that notifies observers of type :class:`Observer`.
+    """
+
+    def __init__(self):
+        self.observers: List[Observer] = []
+
+    def subscribe(self, observer: Observer):
+        """
+        Add observer to the subscribed observers list.
+
+        :param observer: observer
+        :type observer: Observer
+        :return:
+        """
+        self.observers.append(observer)
+
+    def on_next(self, value):
+        """
+        Notify all of the observers.
+
+        :param value:
+        :return:
+        """
+        for observer in self.observers:
+            observer.on_next(value)
+
+    def unsubscribe_all(self):
+        self.observers = []
+
+
+class QueueWorker(Observer, Observable, MetaStepMixin, BaseStep):
+    """
+    Start multiple Process or Thread that process items from the queue of batches to process.
+    It is both an observable, and observer.
+    It notifies the results of the wrapped step handle transform method.
+    It receives the next data container to process.
+
+    .. seealso::
+        :class:`Observer`,
+        :class:`Observable`,
+        :class:`MetaStepMixin`,
+        :class:`BaseStep`
+    """
+
+    def __init__(self, wrapped: BaseStep, max_size: int, n_workers: int, use_threading: bool):
+        Observer.__init__(self)
+        Observable.__init__(self)
+        MetaStepMixin.__init__(self, wrapped)
+        BaseStep.__init__(self)
+
+        self.use_threading: bool = use_threading
+        self.workers: List[Process] = []
+        self.batches_to_process: Queue = Queue(maxsize=max_size)
+        self.n_workers: int = n_workers
+
+    def on_next(self, value):
+        """
+        Add batch to process when the observer receives a value.
+
+        :param value: data container to process
+        :type value: DataContainer
+        :return:
+        """
+        self.batches_to_process.put(value)
+
+    def start(self, context: ExecutionContext):
+        """
+        Start multiple processes or threads with the worker function as a target.
+
+        :param context: execution context
+        :type context: ExecutionContext
+        :return:
+        """
+        self.workers = []
+        for _ in range(self.n_workers):
+            if self.use_threading:
+                p = Thread(target=self.worker_func, args=(self.batches_to_process, context))
+            else:
+                p = Process(target=self.worker_func, args=(self.batches_to_process, context))
+
+            p.daemon = True
+            p.start()
+            self.workers.append(p)
+
+    def stop(self):
+        """
+        Stop all of the workers.
+
+        :return:
+        """
+        if not self.use_threading:
+            [w.kill() for w in self.workers]
+        self.workers = []
+        self.unsubscribe_all()
+
+    def worker_func(self, batches_to_process, context: ExecutionContext):
+        """
+        Worker function that transforms the items inside the queue of items to process.
+
+        :param batches_to_process: multiprocessing queue
+        :param context: execution context
+        :type context: ExecutionContext
+        :return:
+        """
+        while True:
+            data_container = batches_to_process.get()
+            data_container = self.handle_transform(data_container, context)
+            Observable.on_next(self, data_container)
+
+
+# (step_name, n_workers, step)
+# (step_name, n_workers, max_size, step)
+# (step_name, step)
+QueuedPipelineStepsTuple = Union[Tuple[str, int, BaseStep], Tuple[str, int, int, BaseStep], Tuple[str, BaseStep]]
+
+
+class QueuedPipeline(CustomPipelineMixin, Pipeline):
+    """
+    Sub class of :class:`Pipeline`.
+    Transform data in many pipeline steps at once in parallel in the pipeline using multiprocessing Queues.
+
+    Example usage :
+
+    .. code-block:: python
+
+        p = QueuedPipeline([
+            ('step_a', Identity()),
+            ('step_b', Identity()),
+        ], n_workers=1, batch_size=10, max_size=10)
+
+        # or
+
+        p = QueuedPipeline([
+            ('step_a', 1, Identity()),
+            ('step_b', 1, Identity()),
+        ], batch_size=10, max_size=10)
+
+        # or
+
+        p = QueuedPipeline([
+            ('step_a', 1, 10, Identity()),
+            ('step_b', 1, 10, Identity()),
+        ], batch_size=10)
+
+
+    .. seealso::
+        :class:`QueueWorker`,
+        :class:`QueueJoiner`,
+        :class:`CustomPipelineMixin`,
+        :class:`Pipeline`
+    """
+
+    def __init__(self, steps: List[QueuedPipelineStepsTuple], batch_size, n_workers_per_step=None, max_size=None,
+                 use_threading=False, cache_folder=None):
+        CustomPipelineMixin.__init__(self)
+
+        self.max_size = max_size
+        self.batch_size = batch_size
+        self.n_workers_per_step = n_workers_per_step
+        self.use_threading = use_threading
+
+        Pipeline.__init__(self, steps=self._initialize_steps_as_tuple(steps), cache_folder=cache_folder)
+
+    def _initialize_steps_as_tuple(self, steps):
+        """
+        Wrap each step by a :class:`QueueWorker` to  allow data to flow in many pipeline steps at once in parallel.
+
+        :param steps: (name, n_workers, step)
+        :type steps: NameNWorkerStepTupleList
+        :return: steps as tuple
+        :rtype: NamedTupleList
+        """
+        steps_as_tuple: NamedTupleList = []
+        for step in steps:
+            queue_worker = self._create_queue_worker(step)
+            steps_as_tuple.append((queue_worker.name, queue_worker))
+
+        return steps_as_tuple
+
+    def _create_queue_worker(self, step: QueuedPipelineStepsTuple):
+        name, n_workers, max_size, actual_step = self._get_step_params(step)
+
+        return QueueWorker(
+            actual_step,
+            n_workers=n_workers,
+            use_threading=self.use_threading,
+            max_size=max_size
+        )
+
+    def _get_step_params(self, step):
+        """
+        Return all params necessary to create the QueuedPipeline for the given step.
+
+        :param step: tuple
+        :type step: QueuedPipelineStepsTupleList
+
+        :return: return name, n_workers, max_size, actual_step
+        :rtype: tuple(str, int, int, BaseStep)
+        """
+        if len(step) == 2:
+            name, actual_step = step
+            max_size = self.max_size
+            n_workers = self.n_workers_per_step
+        elif len(step) == 3:
+            name, n_workers, actual_step = step
+            max_size = self.max_size
+        elif len(step) == 4:
+            name, n_workers, max_size, actual_step = step
+        else:
+            raise Exception(
+                'Invalid Queued Pipeline Steps Shape. Please use one of the following: (step_name, n_workers, max_size, step), (step_name, n_workers, step), (step_name, step)')
+
+        return name, n_workers, max_size, actual_step
+
+    def _will_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
+        """
+        Start the :class:`QueueWorker` for each step before transforming the data container.
+
+        :param data_container: data container
+        :type data_container: DataContainer
+        :param context: execution context
+        :type context: ExecutionContext
+        :return:
+        """
+        for i, (name, step) in enumerate(self):
+            if i != 0:
+                step.subscribe(self[i - 1])
+            step.start(context)
+
+    def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        """
+        Transform data container
+
+        :param data_container: data container to transform.
+        :type data_container: DataContainer
+        :param context: execution context
+        :type context: ExecutionContext
+        :return: data container
+        """
+        data_container_batches = data_container.convolved_1d(stride=self.batch_size, kernel_size=self.batch_size)
+        n_batches = data_container.get_n_baches(self.batch_size)
+
+        batches_observable = Observable()
+        batches_observable.subscribe(self[0])
+
+        queue_joiner = QueueJoiner(n_batches=n_batches)
+        self[-1].subscribe(queue_joiner)
+
+        for data_container_batch in data_container_batches:
+            batches_observable.on_next(data_container_batch)
+
+        return queue_joiner.join()
+
+    def _did_transform(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        """
+        Stop all of the workers after transform.
+
+        :param data_container: data container
+        :type data_container: DataContainer
+        :param context: execution context
+        :type context: ExecutionContext
+        :return: data container
+        :rtype: DataContainer
+        """
+        for name, step in self:
+            step.stop()
+
+        return data_container
+
+
+class QueueJoiner(Observer):
+    """
+    Observe the results of the queue worker of type :class:`QueueWorker`.
+    Synchronize all of the workers together.
+
+    .. seealso::
+        :class:`QueuedPipeline`,
+        :class:`Observer`,
+        :class:`ListDataContainer`,
+        :class:`DataContainer`
+    """
+
+    def __init__(self, n_batches):
+        self.mutex_processing_in_progress = Lock()
+        self.mutex_processing_in_progress.acquire()
+        self.n_batches_left_to_do = n_batches
+        self.result = ListDataContainer(
+            current_ids=[],
+            data_inputs=[],
+            expected_outputs=[],
+            summary_id=None
+        )
+
+    def on_next(self, value):
+        """
+        Receive the final results of a batch processed by the queued pipeline.
+        Releases the mutex_processing_in_progress if there is no batches left to process.
+
+        :param value: transformed data container batch
+        :type value: DataContainer
+        :return:
+        """
+        self.n_batches_left_to_do -= 1
+
+        self.result.concat(value)
+
+        if self.n_batches_left_to_do == 0:
+            self.mutex_processing_in_progress.release()
+
+    def join(self) -> DataContainer:
+        """
+        Return the accumulated results received by the on next method of this observer.
+
+        :return: transformed data container
+        :rtype: DataContainer
+        """
+        self.mutex_processing_in_progress.acquire()
+        return self.result

--- a/testing/test_streaming.py
+++ b/testing/test_streaming.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+from neuraxle.distributed.streaming import QueuedPipeline
+from neuraxle.steps.misc import TapeCallbackFunction, FitTransformCallbackStep
+
+EXPECTED_OUTPUTS = np.array(range(100)) * 2 * 2 * 2 * 2
+
+
+class MultiplyBy2FitTransformCallbackStep(FitTransformCallbackStep):
+    def fit_transform(self, data_inputs, expected_outputs=None):
+        FitTransformCallbackStep.fit_transform(self, data_inputs, expected_outputs)
+
+        return self, list(np.array(data_inputs) * 2)
+
+
+def test_queued_pipeline_with_step_name_n_worker_max_size():
+    # Given
+    tape1 = TapeCallbackFunction()
+    tape1_fit = TapeCallbackFunction()
+    tape2 = TapeCallbackFunction()
+    tape2_fit = TapeCallbackFunction()
+    tape3 = TapeCallbackFunction()
+    tape3_fit = TapeCallbackFunction()
+    tape4 = TapeCallbackFunction()
+    tape4_fit = TapeCallbackFunction()
+
+    p = QueuedPipeline([
+        ('1', 1, 5, MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
+        ('2', 1, 5, MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
+        ('3', 1, 5, MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
+        ('4', 1, 5, MultiplyBy2FitTransformCallbackStep(tape4, tape4_fit, ["4"])),
+    ], batch_size=10)
+
+    # When
+    p, outputs = p.fit_transform(range(100), range(100))
+
+    assert np.array_equal(outputs, EXPECTED_OUTPUTS)
+
+
+def test_queued_pipeline_with_step_name_n_worker_with_step_name_n_workers_and_default_max_size():
+    # Given
+    tape1 = TapeCallbackFunction()
+    tape1_fit = TapeCallbackFunction()
+    tape2 = TapeCallbackFunction()
+    tape2_fit = TapeCallbackFunction()
+    tape3 = TapeCallbackFunction()
+    tape3_fit = TapeCallbackFunction()
+    tape4 = TapeCallbackFunction()
+    tape4_fit = TapeCallbackFunction()
+
+    p = QueuedPipeline([
+        ('1', 1, MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
+        ('2', 1, MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
+        ('3', 1, MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
+        ('4', 1, MultiplyBy2FitTransformCallbackStep(tape4, tape4_fit, ["4"])),
+    ], max_size=10, batch_size=10)
+
+    # When
+    p, outputs = p.fit_transform(range(100), range(100))
+
+    assert np.array_equal(outputs, EXPECTED_OUTPUTS)
+
+
+def test_queued_pipeline_with_step_name_n_worker_with_default_n_workers_and_default_max_size():
+    # Given
+    tape1 = TapeCallbackFunction()
+    tape1_fit = TapeCallbackFunction()
+    tape2 = TapeCallbackFunction()
+    tape2_fit = TapeCallbackFunction()
+    tape3 = TapeCallbackFunction()
+    tape3_fit = TapeCallbackFunction()
+    tape4 = TapeCallbackFunction()
+    tape4_fit = TapeCallbackFunction()
+
+    p = QueuedPipeline([
+        ('1', MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
+        ('2', MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
+        ('3', MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
+        ('4', MultiplyBy2FitTransformCallbackStep(tape4, tape4_fit, ["4"])),
+    ], n_workers_per_step=1, max_size=10, batch_size=10)
+
+    # When
+    p, outputs = p.fit_transform(range(100), range(100))
+
+    assert np.array_equal(outputs, EXPECTED_OUTPUTS)

--- a/testing/test_streaming.py
+++ b/testing/test_streaming.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from neuraxle.distributed.streaming import QueuedPipeline
+from neuraxle.distributed.streaming import SequentialQueuedPipeline, ParallelQueuedPipeline
 from neuraxle.steps.misc import TapeCallbackFunction, FitTransformCallbackStep
 
 EXPECTED_OUTPUTS = np.array(range(100)) * 2 * 2 * 2 * 2
@@ -24,7 +24,7 @@ def test_queued_pipeline_with_step_name_n_worker_max_size():
     tape4 = TapeCallbackFunction()
     tape4_fit = TapeCallbackFunction()
 
-    p = QueuedPipeline([
+    p = SequentialQueuedPipeline([
         ('1', 1, 5, MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
         ('2', 1, 5, MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
         ('3', 1, 5, MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
@@ -32,7 +32,7 @@ def test_queued_pipeline_with_step_name_n_worker_max_size():
     ], batch_size=10)
 
     # When
-    p, outputs = p.fit_transform(range(100), range(100))
+    p, outputs = p.fit_transform(list(range(100)), list(range(100)))
 
     assert np.array_equal(outputs, EXPECTED_OUTPUTS)
 
@@ -48,7 +48,7 @@ def test_queued_pipeline_with_step_name_n_worker_with_step_name_n_workers_and_de
     tape4 = TapeCallbackFunction()
     tape4_fit = TapeCallbackFunction()
 
-    p = QueuedPipeline([
+    p = SequentialQueuedPipeline([
         ('1', 1, MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
         ('2', 1, MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
         ('3', 1, MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
@@ -56,7 +56,7 @@ def test_queued_pipeline_with_step_name_n_worker_with_step_name_n_workers_and_de
     ], max_size=10, batch_size=10)
 
     # When
-    p, outputs = p.fit_transform(range(100), range(100))
+    p, outputs = p.fit_transform(list(range(100)), list(range(100)))
 
     assert np.array_equal(outputs, EXPECTED_OUTPUTS)
 
@@ -72,7 +72,7 @@ def test_queued_pipeline_with_step_name_n_worker_with_default_n_workers_and_defa
     tape4 = TapeCallbackFunction()
     tape4_fit = TapeCallbackFunction()
 
-    p = QueuedPipeline([
+    p = SequentialQueuedPipeline([
         ('1', MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
         ('2', MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
         ('3', MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
@@ -80,6 +80,78 @@ def test_queued_pipeline_with_step_name_n_worker_with_default_n_workers_and_defa
     ], n_workers_per_step=1, max_size=10, batch_size=10)
 
     # When
-    p, outputs = p.fit_transform(range(100), range(100))
+    p, outputs = p.fit_transform(list(range(100)), list(range(100)))
+
+    assert np.array_equal(outputs, EXPECTED_OUTPUTS)
+
+
+def test_parallel_queued_pipeline_with_step_name_n_worker_max_size():
+    # Given
+    tape1 = TapeCallbackFunction()
+    tape1_fit = TapeCallbackFunction()
+    tape2 = TapeCallbackFunction()
+    tape2_fit = TapeCallbackFunction()
+    tape3 = TapeCallbackFunction()
+    tape3_fit = TapeCallbackFunction()
+    tape4 = TapeCallbackFunction()
+    tape4_fit = TapeCallbackFunction()
+
+    p = ParallelQueuedPipeline([
+        ('1', 1, 5, MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
+        ('2', 1, 5, MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
+        ('3', 1, 5, MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
+        ('4', 1, 5, MultiplyBy2FitTransformCallbackStep(tape4, tape4_fit, ["4"])),
+    ], batch_size=10)
+
+    # When
+    p, outputs = p.fit_transform(list(range(100)), list(range(100)))
+
+    assert np.array_equal(outputs, EXPECTED_OUTPUTS)
+
+
+def test_parallel_queued_pipeline_with_step_name_n_worker_with_step_name_n_workers_and_default_max_size():
+    # Given
+    tape1 = TapeCallbackFunction()
+    tape1_fit = TapeCallbackFunction()
+    tape2 = TapeCallbackFunction()
+    tape2_fit = TapeCallbackFunction()
+    tape3 = TapeCallbackFunction()
+    tape3_fit = TapeCallbackFunction()
+    tape4 = TapeCallbackFunction()
+    tape4_fit = TapeCallbackFunction()
+
+    p = ParallelQueuedPipeline([
+        ('1', 1, MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
+        ('2', 1, MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
+        ('3', 1, MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
+        ('4', 1, MultiplyBy2FitTransformCallbackStep(tape4, tape4_fit, ["4"])),
+    ], max_size=10, batch_size=10)
+
+    # When
+    p, outputs = p.fit_transform(list(range(100)), list(range(100)))
+
+    assert np.array_equal(outputs, EXPECTED_OUTPUTS)
+
+
+def test_parallel_queued_pipeline_with_step_name_n_worker_with_default_n_workers_and_default_max_size():
+    # Given
+    tape1 = TapeCallbackFunction()
+    tape1_fit = TapeCallbackFunction()
+    tape2 = TapeCallbackFunction()
+    tape2_fit = TapeCallbackFunction()
+    tape3 = TapeCallbackFunction()
+    tape3_fit = TapeCallbackFunction()
+    tape4 = TapeCallbackFunction()
+    tape4_fit = TapeCallbackFunction()
+
+    p = ParallelQueuedPipeline([
+        ('1', MultiplyBy2FitTransformCallbackStep(tape1, tape1_fit, ["1"])),
+        ('2', MultiplyBy2FitTransformCallbackStep(tape2, tape2_fit, ["2"])),
+        ('3', MultiplyBy2FitTransformCallbackStep(tape3, tape3_fit, ["3"])),
+        ('4', MultiplyBy2FitTransformCallbackStep(tape4, tape4_fit, ["4"])),
+    ], n_workers_per_step=1, max_size=10, batch_size=10)
+
+    # When
+    p, outputs = p.fit_transform(list(range(100)), list(range(100)))
 
     assert np.array_equal(outputs, EXPECTED_OUTPUTS)


### PR DESCRIPTION
- QueuedPipeline class in neuraxle.distributed.streaming creates a QueueWorker for each step inside the pipeline. 
- Each QueueWorker has an internal Queue with a max size.  
- Each QueueWorker creates n_workers Process(or thread if QueuedPipeline.use_threading=true) that process items in the multiprocessing Queue. 
- Each QueueWorker are both observable, and observers. 
- Each QueueWorker observes the results of the previous QueueWorker.
- All the results are joined together at the end by a QueueJoiner that listens to the last QueueWorker.  

Usage Example : 
```
# or shape: (name, step)
p = QueuedPipeline([
      ('step_a', Identity()),
      ('step_b', Identity()),
], n_workers=1, batch_size=10, max_size=10)

# or shape: (name, n_workers, step)
p = QueuedPipeline([
      ('step_a', 1, Identity()),
      ('step_b', 1, Identity()),
], batch_size=10, max_size=10)

# or shape: (name, n_workers, max_size, step)
p = QueuedPipeline([
      ('step_a', 1, 10, Identity()),
      ('step_b', 1, 10, Identity()),
], batch_size=10)
```

In progress : 

Two concrete class that inherit from BaseQueuedPipeline 

> SequentialQueuedPipeline, ParallelQueuedPipeline