### PR TITLE
Fix Issue #332 : Fix shallow copy in automl loop. 

### DIFF
--- a/neuraxle/metaopt/auto_ml.py
+++ b/neuraxle/metaopt/auto_ml.py
@@ -481,9 +481,9 @@ class Trainer:
 
         for i in range(self.epochs):
             self.print_func('\nepoch {}/{}'.format(i + 1, self.epochs))
-            trial_split = trial_split.fit_trial_split(train_data_container, context)
-            y_pred_train = trial_split.predict_with_pipeline(train_data_container, context)
-            y_pred_val = trial_split.predict_with_pipeline(validation_data_container, context)
+            trial_split = trial_split.fit_trial_split(train_data_container.copy(), context)
+            y_pred_train = trial_split.predict_with_pipeline(train_data_container.copy(), context)
+            y_pred_val = trial_split.predict_with_pipeline(validation_data_container.copy(), context)
 
             if self.callbacks.call(
                     trial=trial_split,


### PR DESCRIPTION
My pull request does: 

Add a shallow copy in the `fit_trial_split` method inside the `Trainer` because the pipeline could change the reference of the data inputs directly, and change the values for the next epochs. 

 ```python
   def fit_trial_split(
            self,
            trial_split: TrialSplit,
            train_data_container: DataContainer,
            validation_data_container: DataContainer,
            context: ExecutionContext
    ) -> TrialSplit:
        """
        Train pipeline using the training data container.
        Track training, and validation metrics for each epoch.

        :param train_data_container: train data container
        :param validation_data_container: validation data container
        :param trial_split: trial to execute
        :param context: execution context

        :return: executed trial
        """
        early_stopping = False

        for i in range(self.epochs):
            self.print_func('\nepoch {}/{}'.format(i + 1, self.epochs))

            # shallow copy here to create a new reference for the data inputs inside the data container. 
            trial_split = trial_split.fit_trial_split(train_data_container.copy(), context)
            y_pred_train = trial_split.predict_with_pipeline(train_data_container.copy(), context)
            y_pred_val = trial_split.predict_with_pipeline(validation_data_container.copy(), context)

            if self.callbacks.call(
                    trial=trial_split,
                    epoch_number=i,
                    total_epochs=self.epochs,
                    input_train=train_data_container,
                    pred_train=y_pred_train,
                    input_val=validation_data_container,
                    pred_val=y_pred_val,
                    is_finished_and_fitted=early_stopping
            ):
                break

        return trial_split
```