### PR TITLE
Create _FittableStep, and _TransformerStep

### DIFF
--- a/examples/getting_started/plot_non_fittable_mixin.py
+++ b/examples/getting_started/plot_non_fittable_mixin.py
@@ -36,11 +36,11 @@ BaseStep class.
 """
 import numpy as np
 
-from neuraxle.base import NonTransformableMixin, NonFittableMixin, Identity, BaseStep
+from neuraxle.base import NonTransformableMixin, Identity, BaseStep
 from neuraxle.pipeline import Pipeline
 
 
-class NonFittableStep(NonFittableMixin, BaseStep):
+class NonFittableStep(BaseStep):
     """
     Fit method is automatically implemented as changing nothing.
     Please make your steps inherit from NonFittableMixin, when they don't need any fitting.

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -494,7 +494,6 @@ class _TransformerStep:
         :param context: execution context
         :return: (data container, execution context)
         """
-        self.setup()
         return data_container, context
 
     def handle_fit(self, data_container: DataContainer, context: ExecutionContext) -> 'BaseStep':

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -567,6 +567,17 @@ class _TransformerStep:
     def __call__(self, *args, **kwargs) -> Any:
         return self.transform(*args)
 
+    def fit_transform(self, data_inputs, expected_outputs=None):
+        """
+        Fit transform given data inputs. By default, a step only transforms in the fit transform method.
+        To add fitting to your step, see class:`_FittableStep` for more info.
+
+        :param data_inputs: data inputs
+        :param expected_outputs: expected outputs to fit on
+        :return: transformed data inputs
+        """
+        return self, self.transform(data_inputs)
+
     @abstractmethod
     def transform(self, data_inputs):
         """
@@ -681,6 +692,9 @@ class _TransformerStep:
 
 
 class _FittableStep:
+    def __init__(self, fit_data_container_callback=None, fit_transform_data_container_callback=None, transform_data_container_callback=None):
+        pass
+
     def handle_fit(self, data_container: DataContainer, context: ExecutionContext) -> 'BaseStep':
         """
         Override this to add side effects or change the execution flow before (or after) calling :func:`~neuraxle.base.BaseStep.fit`.
@@ -700,6 +714,7 @@ class _FittableStep:
         new_self = self._fit_data_container(data_container, context)
 
         self._did_fit(data_container, context)
+        self._did_process(data_container, context)
 
         return new_self
 

--- a/neuraxle/checkpoints.py
+++ b/neuraxle/checkpoints.py
@@ -31,7 +31,7 @@ from enum import Enum
 from typing import List, Tuple, Any
 
 from neuraxle.base import ResumableStepMixin, BaseStep, ExecutionContext, \
-    ExecutionMode, NonTransformableMixin, NonFittableMixin, Identity
+    ExecutionMode, NonTransformableMixin, Identity
 from neuraxle.data_container import DataContainer, ListDataContainer
 
 
@@ -40,7 +40,7 @@ class DataCheckpointType(Enum):
     EXPECTED_OUTPUT = 'eo'
 
 
-class BaseCheckpointer(NonFittableMixin, NonTransformableMixin, BaseStep):
+class BaseCheckpointer(NonTransformableMixin, BaseStep):
     """
     Base class to implement a step checkpoint or data container checkpoint.
 
@@ -163,7 +163,7 @@ class StepSavingCheckpointer(BaseCheckpointer):
         return True
 
 
-class Checkpoint(NonFittableMixin, NonTransformableMixin, ResumableStepMixin, BaseStep):
+class Checkpoint(NonTransformableMixin, ResumableStepMixin, BaseStep):
     """
     Resumable Checkpoint Step to load, and save both data checkpoints, and step checkpoints.
     Checkpoint uses a list of step checkpointers(List[StepCheckpointer]), and data checkpointers(List[BaseCheckpointer]).
@@ -193,7 +193,6 @@ class Checkpoint(NonFittableMixin, NonTransformableMixin, ResumableStepMixin, Ba
         :class:`~neuraxle.base.BaseStep`,
         :func:`neuraxle.pipeline.ResumablePipeline._load_checkpoint`,
         :class:`~neuraxle.base.ResumableStepMixin`,
-        :class:`~neuraxle.base.NonFittableMixin`,
         :class:`~neuraxle.base.NonTransformableMixin`
     """
 

--- a/neuraxle/checkpoints.py
+++ b/neuraxle/checkpoints.py
@@ -31,7 +31,7 @@ from enum import Enum
 from typing import List, Tuple, Any
 
 from neuraxle.base import ResumableStepMixin, BaseStep, ExecutionContext, \
-    ExecutionMode, NonTransformableMixin, Identity
+    ExecutionMode, NonTransformableMixin, Identity, _FittableStep, HandleOnlyMixin
 from neuraxle.data_container import DataContainer, ListDataContainer
 
 
@@ -163,7 +163,7 @@ class StepSavingCheckpointer(BaseCheckpointer):
         return True
 
 
-class Checkpoint(NonTransformableMixin, ResumableStepMixin, BaseStep):
+class Checkpoint(NonTransformableMixin, HandleOnlyMixin, ResumableStepMixin, _FittableStep, BaseStep):
     """
     Resumable Checkpoint Step to load, and save both data checkpoints, and step checkpoints.
     Checkpoint uses a list of step checkpointers(List[StepCheckpointer]), and data checkpointers(List[BaseCheckpointer]).
@@ -201,6 +201,9 @@ class Checkpoint(NonTransformableMixin, ResumableStepMixin, BaseStep):
             all_checkpointers: List[BaseCheckpointer] = None,
     ):
         BaseStep.__init__(self)
+        _FittableStep.__init__(self)
+        ResumableStepMixin.__init__(self)
+        HandleOnlyMixin.__init__(self)
         self.all_checkpointers = all_checkpointers
 
     def _fit_data_container(self, data_container, context) -> 'Checkpoint':

--- a/neuraxle/distributed/streaming.py
+++ b/neuraxle/distributed/streaming.py
@@ -27,7 +27,7 @@ from multiprocessing.context import Process
 from threading import Thread
 from typing import Tuple, List, Union, Iterable
 
-from neuraxle.base import NamedTupleList, ExecutionContext, BaseStep, MetaStepMixin, NonFittableMixin, BaseSaver
+from neuraxle.base import NamedTupleList, ExecutionContext, BaseStep, MetaStepMixin, BaseSaver, _FittableStep
 from neuraxle.data_container import DataContainer, ListDataContainer
 from neuraxle.pipeline import Pipeline, CustomPipelineMixin, MiniBatchSequentialPipeline, Joiner
 from neuraxle.steps.numpy import NumpyConcatenateOuterBatch
@@ -307,7 +307,6 @@ class BaseQueuedPipeline(MiniBatchSequentialPipeline):
             use_savers=False,
             cache_folder=None
     ):
-        NonFittableMixin.__init__(self)
         CustomPipelineMixin.__init__(self)
 
         if data_joiner is None:
@@ -421,7 +420,7 @@ class BaseQueuedPipeline(MiniBatchSequentialPipeline):
         all_steps_are_not_fittable = True
 
         for _, step in self[:-1]:
-            if not isinstance(step.get_step(), NonFittableMixin):
+            if not isinstance(step.get_step(), _FittableStep):
                 all_steps_are_not_fittable = False
 
         if all_steps_are_not_fittable:

--- a/neuraxle/distributed/streaming.py
+++ b/neuraxle/distributed/streaming.py
@@ -29,7 +29,7 @@ from typing import Tuple, List, Union, Iterable
 
 from neuraxle.base import NamedTupleList, ExecutionContext, BaseStep, MetaStepMixin, BaseSaver, _FittableStep
 from neuraxle.data_container import DataContainer, ListDataContainer
-from neuraxle.pipeline import Pipeline, CustomPipelineMixin, MiniBatchSequentialPipeline, Joiner
+from neuraxle.pipeline import Pipeline, MiniBatchSequentialPipeline, Joiner
 from neuraxle.steps.numpy import NumpyConcatenateOuterBatch
 
 

--- a/neuraxle/distributed/streaming.py
+++ b/neuraxle/distributed/streaming.py
@@ -442,7 +442,7 @@ class BaseQueuedPipeline(MiniBatchSequentialPipeline):
         all_steps_are_not_fittable = True
 
         for _, step in self[:-1]:
-            if not isinstance(step.get_step(), _FittableStep):
+            if isinstance(step.get_step(), _FittableStep):
                 all_steps_are_not_fittable = False
 
         if all_steps_are_not_fittable:

--- a/neuraxle/metaopt/auto_ml.py
+++ b/neuraxle/metaopt/auto_ml.py
@@ -37,7 +37,7 @@ from typing import Callable, List, Union, Tuple
 
 import numpy as np
 
-from neuraxle.base import BaseStep, ExecutionContext, ForceHandleOnlyMixin
+from neuraxle.base import BaseStep, ExecutionContext, ForceHandleOnlyMixin, ForceHandleMixin, _FittableStep
 from neuraxle.data_container import DataContainer
 from neuraxle.hyperparams.space import HyperparameterSamples, HyperparameterSpace
 from neuraxle.metaopt.callbacks import BaseCallback, CallbackList, ScoringCallback
@@ -538,7 +538,7 @@ class Trainer:
         return self.callbacks[0].name
 
 
-class AutoML(ForceHandleOnlyMixin, BaseStep):
+class AutoML(ForceHandleMixin, _FittableStep, BaseStep):
     """
     A step to execute any Automatic Machine Learning Algorithms.
 
@@ -593,7 +593,8 @@ class AutoML(ForceHandleOnlyMixin, BaseStep):
             cache_folder_when_no_handle=None
     ):
         BaseStep.__init__(self)
-        ForceHandleOnlyMixin.__init__(self, cache_folder=cache_folder_when_no_handle)
+        _FittableStep.__init__(self)
+        ForceHandleMixin.__init__(self, cache_folder=cache_folder_when_no_handle)
 
         self.validation_split_function: BaseValidationSplitter = validation_splitter
 

--- a/neuraxle/metaopt/auto_ml.py
+++ b/neuraxle/metaopt/auto_ml.py
@@ -481,9 +481,9 @@ class Trainer:
 
         for i in range(self.epochs):
             self.print_func('\nepoch {}/{}'.format(i + 1, self.epochs))
-            trial_split = trial_split.fit_trial_split(train_data_container, context)
-            y_pred_train = trial_split.predict_with_pipeline(train_data_container, context)
-            y_pred_val = trial_split.predict_with_pipeline(validation_data_container, context)
+            trial_split = trial_split.fit_trial_split(train_data_container.copy(), context)
+            y_pred_train = trial_split.predict_with_pipeline(train_data_container.copy(), context)
+            y_pred_val = trial_split.predict_with_pipeline(validation_data_container.copy(), context)
 
             if self.callbacks.call(
                     trial=trial_split,

--- a/neuraxle/metaopt/deprecated.py
+++ b/neuraxle/metaopt/deprecated.py
@@ -28,7 +28,7 @@ import numpy as np
 from sklearn.metrics import r2_score
 
 from neuraxle.base import MetaStepMixin, BaseStep, ExecutionContext, ForceHandleOnlyMixin, \
-    EvaluableStepMixin
+    EvaluableStepMixin, _FittableStep
 from neuraxle.data_container import DataContainer
 from neuraxle.hyperparams.space import HyperparameterSamples, HyperparameterSpace
 

--- a/neuraxle/metaopt/random.py
+++ b/neuraxle/metaopt/random.py
@@ -32,7 +32,7 @@ import numpy as np
 from sklearn.metrics import r2_score
 
 from neuraxle.base import MetaStepMixin, BaseStep, ExecutionContext, HandleOnlyMixin, ForceHandleOnlyMixin, \
-    EvaluableStepMixin
+    EvaluableStepMixin, _FittableStep
 from neuraxle.data_container import DataContainer
 from neuraxle.steps.loop import StepClonerForEachDataInput
 from neuraxle.steps.numpy import NumpyConcatenateOuterBatch, NumpyConcatenateOnCustomAxis

--- a/neuraxle/metrics.py
+++ b/neuraxle/metrics.py
@@ -21,7 +21,7 @@ The neuraxle classes to track metrics results.
 """
 from typing import Dict
 
-from neuraxle.base import MetaStepMixin, BaseStep, ExecutionContext
+from neuraxle.base import MetaStepMixin, BaseStep, ExecutionContext, _FittableStep
 from neuraxle.data_container import DataContainer
 
 

--- a/neuraxle/rest/flask.py
+++ b/neuraxle/rest/flask.py
@@ -28,11 +28,11 @@ from abc import ABC, abstractmethod
 import numpy as np
 from flask import Response
 
-from neuraxle.base import BaseStep, NonFittableMixin
+from neuraxle.base import BaseStep
 from neuraxle.pipeline import Pipeline
 
 
-class JSONDataBodyDecoder(NonFittableMixin, BaseStep, ABC):
+class JSONDataBodyDecoder(BaseStep, ABC):
     """
     Class to be used within a FlaskRESTApiWrapper to convert input json to actual data (e.g.: arrays)
     """
@@ -51,7 +51,7 @@ class JSONDataBodyDecoder(NonFittableMixin, BaseStep, ABC):
         raise NotImplementedError("TODO: inherit from the `JSONDataBodyDecoder` class and implement this method.")
 
 
-class JSONDataResponseEncoder(NonFittableMixin, BaseStep, ABC):
+class JSONDataResponseEncoder(BaseStep, ABC):
     """
     Base class to be used within a FlaskRESTApiWrapper to convert prediction output to json response.
     """

--- a/neuraxle/steps/column_transformer.py
+++ b/neuraxle/steps/column_transformer.py
@@ -28,7 +28,7 @@ from typing import List, Tuple, Union
 
 import numpy as np
 
-from neuraxle.base import BaseStep, NonFittableMixin, MetaStepMixin
+from neuraxle.base import BaseStep, MetaStepMixin
 from neuraxle.pipeline import Pipeline
 from neuraxle.steps.loop import ForEachDataInput
 from neuraxle.union import FeatureUnion
@@ -37,7 +37,7 @@ ColumnSelectionType = Union[Tuple[int, BaseStep], Tuple[List[int], BaseStep], Tu
 ColumnChooserTupleList = List[ColumnSelectionType]
 
 
-class ColumnSelector2D(NonFittableMixin, BaseStep):
+class ColumnSelector2D(BaseStep):
     """
     A ColumnSelector2D selects column in a sequence.
     """

--- a/neuraxle/steps/data.py
+++ b/neuraxle/steps/data.py
@@ -22,8 +22,8 @@ You can find here steps that take action on data.
 import random
 from typing import Iterable
 
-from neuraxle.base import BaseStep, MetaStepMixin, NonFittableMixin, ExecutionContext, HandleOnlyMixin, \
-    ForceHandleOnlyMixin
+from neuraxle.base import BaseStep, MetaStepMixin, ExecutionContext, HandleOnlyMixin, \
+    ForceHandleOnlyMixin, _FittableStep
 from neuraxle.base import NonTransformableMixin
 from neuraxle.data_container import DataContainer, _inner_concatenate_np_array
 from neuraxle.pipeline import Pipeline
@@ -31,7 +31,7 @@ from neuraxle.steps.flow import TrainOnlyWrapper
 from neuraxle.steps.output_handlers import InputAndOutputTransformerMixin
 
 
-class DataShuffler(NonFittableMixin, InputAndOutputTransformerMixin, BaseStep):
+class DataShuffler(InputAndOutputTransformerMixin, BaseStep):
     """
     Data Shuffling step that shuffles data inputs, and expected_outputs at the same time.
 
@@ -197,7 +197,7 @@ class TrainShuffled(Pipeline):
         ])
 
 
-class InnerConcatenateDataContainer(NonFittableMixin, NonTransformableMixin, BaseStep):
+class InnerConcatenateDataContainer(NonTransformableMixin, BaseStep):
     """
     Concatenate inner features of sub data containers along `axis=-1`..
 
@@ -223,7 +223,6 @@ class InnerConcatenateDataContainer(NonFittableMixin, NonTransformableMixin, Bas
 
 
     .. seealso::
-        :class:`~neuraxle.base.NonFittableMixin`,
         :class:`~neuraxle.base.NonTransformableMixin`,
         :class:`~neuraxle.base.BaseStep`
         :class:`~neuraxle.data_container.DataContainer`
@@ -232,7 +231,6 @@ class InnerConcatenateDataContainer(NonFittableMixin, NonTransformableMixin, Bas
     def __init__(self, sub_data_container_names=None):
         BaseStep.__init__(self)
         NonTransformableMixin.__init__(self)
-        NonFittableMixin.__init__(self)
 
         self.data_sources = sub_data_container_names
 
@@ -305,7 +303,7 @@ class InnerConcatenateDataContainer(NonFittableMixin, NonTransformableMixin, Bas
         return data_container
 
 
-class ZipBatchDataContainer(NonFittableMixin, NonTransformableMixin, BaseStep):
+class ZipBatchDataContainer(NonTransformableMixin, BaseStep):
     """
     Concatenate outer batch of sub data containers along `axis=0`..
 
@@ -331,7 +329,6 @@ class ZipBatchDataContainer(NonFittableMixin, NonTransformableMixin, BaseStep):
 
 
     .. seealso::
-        :class:`~neuraxle.base.NonFittableMixin`,
         :class:`~neuraxle.base.NonTransformableMixin`,
         :class:`~neuraxle.base.BaseStep`
         :class:`~neuraxle.data_container.DataContainer`
@@ -340,7 +337,6 @@ class ZipBatchDataContainer(NonFittableMixin, NonTransformableMixin, BaseStep):
     def __init__(self, sub_data_container_names=None):
         BaseStep.__init__(self)
         NonTransformableMixin.__init__(self)
-        NonFittableMixin.__init__(self)
 
         self.data_sources = sub_data_container_names
 

--- a/neuraxle/steps/flow.py
+++ b/neuraxle/steps/flow.py
@@ -26,7 +26,7 @@ Pipeline wrapper steps that only implement the handle methods, and don't apply a
 from typing import Union
 
 from neuraxle.base import BaseStep, MetaStepMixin, DataContainer, ExecutionContext, TruncableSteps, ResumableStepMixin, \
-    HandleOnlyMixin, TransformHandlerOnlyMixin, ForceHandleOnlyMixin, NonFittableMixin
+    HandleOnlyMixin, TransformHandlerOnlyMixin, ForceHandleOnlyMixin, _FittableStep
 from neuraxle.data_container import ExpandedDataContainer
 from neuraxle.hyperparams.distributions import Boolean, Choice
 from neuraxle.hyperparams.space import HyperparameterSamples, HyperparameterSpace
@@ -401,7 +401,7 @@ class ChooseOneOrManyStepsOf(FeatureUnion):
         self._refresh_steps()
 
 
-class NumpyConcatenateOnCustomAxisIfNotEmpty(NonFittableMixin, BaseStep):
+class NumpyConcatenateOnCustomAxisIfNotEmpty(BaseStep):
     """
     Numpy concetenation step where the concatenation is performed along the specified custom axis.
     """
@@ -414,7 +414,6 @@ class NumpyConcatenateOnCustomAxisIfNotEmpty(NonFittableMixin, BaseStep):
         """
         self.axis = axis
         BaseStep.__init__(self)
-        NonFittableMixin.__init__(self)
 
     def _transform_data_container(self, data_container, context):
         """

--- a/neuraxle/steps/flow.py
+++ b/neuraxle/steps/flow.py
@@ -542,7 +542,7 @@ class ExpandDim(
         return False
 
 
-class ReversiblePreprocessingWrapper(HandleOnlyMixin, TruncableSteps):
+class ReversiblePreprocessingWrapper(HandleOnlyMixin, _FittableStep, TruncableSteps):
     """
     TruncableSteps with a preprocessing step(1), and a postprocessing step(2)
     that inverse transforms with the preprocessing step at the end (1, 2, reversed(1)).
@@ -563,11 +563,12 @@ class ReversiblePreprocessingWrapper(HandleOnlyMixin, TruncableSteps):
     """
 
     def __init__(self, preprocessing_step, postprocessing_step):
-        HandleOnlyMixin.__init__(self)
         TruncableSteps.__init__(self, [
             ("preprocessing_step", preprocessing_step),
             ("postprocessing_step", postprocessing_step)
         ])
+        _FittableStep.__init__(self)
+        HandleOnlyMixin.__init__(self)
 
     def _fit_data_container(self, data_container: DataContainer,
                             context: ExecutionContext) -> 'ReversiblePreprocessingWrapper':

--- a/neuraxle/steps/loop.py
+++ b/neuraxle/steps/loop.py
@@ -28,7 +28,7 @@ from typing import List
 import numpy as np
 
 from neuraxle.base import MetaStepMixin, BaseStep, DataContainer, ExecutionContext, ResumableStepMixin, \
-    ForceHandleOnlyMixin, ForceHandleMixin, TruncableJoblibStepSaver, NamedTupleList
+    ForceHandleOnlyMixin, ForceHandleMixin, TruncableJoblibStepSaver, NamedTupleList, _FittableStep
 from neuraxle.data_container import ListDataContainer
 from neuraxle.hyperparams.space import HyperparameterSamples, HyperparameterSpace
 
@@ -42,7 +42,6 @@ class ForEachDataInput(ForceHandleOnlyMixin, ResumableStepMixin, MetaStepMixin, 
         :class:`~neuraxle.base.BaseSaver`,
         :class:`~neuraxle.base.BaseHasher`,
         :class:`~neuraxle.base.ResumableStepMixin`,
-        :class:`~neuraxle.base.NonFittableMixin`,
         :class:`~neuraxle.base.NonTransformableMixin`,
         :class:`~neuraxle.pipeline.Pipeline`,
         :class:`~neuraxle.hyperparams.space.HyperparameterSamples`,
@@ -296,7 +295,6 @@ class FlattenForEach(ForceHandleMixin, ResumableStepMixin, MetaStepMixin, BaseSt
         :class:`~neuraxle.base.BaseHasher`,
         :class:`~neuraxle.base.ResumableStepMixin`,
         :class:`~neuraxle.base.MetaStepMixin`,
-        :class:`~neuraxle.base.NonFittableMixin`,
         :class:`~neuraxle.base.NonTransformableMixin`,
         :class:`~neuraxle.pipeline.Pipeline`,
         :class:`~neuraxle.hyperparams.space.HyperparameterSamples`,

--- a/neuraxle/steps/misc.py
+++ b/neuraxle/steps/misc.py
@@ -30,8 +30,8 @@ from abc import ABC
 VALUE_CACHING = 'value_caching'
 from typing import List, Any
 
-from neuraxle.base import BaseStep, NonFittableMixin, NonTransformableMixin, ExecutionContext, MetaStepMixin, \
-    HandleOnlyMixin
+from neuraxle.base import BaseStep, NonTransformableMixin, ExecutionContext, MetaStepMixin, \
+    HandleOnlyMixin, _FittableStep
 from neuraxle.data_container import DataContainer
 
 
@@ -92,7 +92,7 @@ class FitCallbackStep(NonTransformableMixin, BaseCallbackStep):
         return self
 
 
-class TransformCallbackStep(NonFittableMixin, BaseCallbackStep):
+class TransformCallbackStep(BaseCallbackStep):
     """Call a callback method on transform and inverse transform."""
 
     def fit_transform(self, data_inputs, expected_outputs=None) -> ('BaseStep', Any):
@@ -128,11 +128,12 @@ class TransformCallbackStep(NonFittableMixin, BaseCallbackStep):
         return processed_outputs
 
 
-class FitTransformCallbackStep(BaseStep):
+class FitTransformCallbackStep(_FittableStep, BaseStep):
     def __init__(self, transform_callback_function=None, fit_callback_function=None, more_arguments: List = tuple(),
                  transform_function=None,
                  hyperparams=None):
         BaseStep.__init__(self, hyperparams)
+
         if transform_callback_function is None:
             transform_callback_function = TapeCallbackFunction()
         if fit_callback_function is None:
@@ -377,7 +378,7 @@ class HandleCallbackStep(HandleOnlyMixin, BaseStep):
         return self, data_container
 
 
-class Sleep(NonFittableMixin, BaseStep):
+class Sleep(BaseStep):
     def __init__(self, sleep_time=0.1, hyperparams=None, hyperparams_space=None):
         BaseStep.__init__(self, hyperparams=hyperparams, hyperparams_space=hyperparams_space)
         self.sleep_time = sleep_time

--- a/neuraxle/steps/numpy.py
+++ b/neuraxle/steps/numpy.py
@@ -26,21 +26,20 @@ Those steps works with NumPy (np) arrays.
 
 import numpy as np
 
-from neuraxle.base import NonFittableMixin, BaseStep, DataContainer, ExecutionContext, ForceHandleOnlyMixin, \
+from neuraxle.base import BaseStep, DataContainer, ExecutionContext, ForceHandleOnlyMixin, \
     ForceHandleMixin
 from neuraxle.hyperparams.space import HyperparameterSamples
 
 
-class NumpyFlattenDatum(NonFittableMixin, BaseStep):
+class NumpyFlattenDatum(BaseStep):
     def __init__(self):
         BaseStep.__init__(self)
-        NonFittableMixin.__init__(self)
 
     def transform(self, data_inputs):
         return data_inputs.reshape(data_inputs.shape[0], -1)
 
 
-class NumpyConcatenateOnCustomAxis(NonFittableMixin, BaseStep):
+class NumpyConcatenateOnCustomAxis(BaseStep):
     """
     Numpy concetenation step where the concatenation is performed along the specified custom axis.
     """
@@ -53,7 +52,6 @@ class NumpyConcatenateOnCustomAxis(NonFittableMixin, BaseStep):
         """
         self.axis = axis
         BaseStep.__init__(self)
-        NonFittableMixin.__init__(self)
 
     def _transform_data_container(self, data_container, context):
         """
@@ -109,10 +107,9 @@ class NumpyConcatenateOuterBatch(NumpyConcatenateOnCustomAxis):
         NumpyConcatenateOnCustomAxis.__init__(self, axis=0)
 
 
-class NumpyTranspose(NonFittableMixin, BaseStep):
+class NumpyTranspose(BaseStep):
     def __init__(self):
         BaseStep.__init__(self)
-        NonFittableMixin.__init__(self)
 
     def _transform_data_container(self, data_container, context):
         """
@@ -139,12 +136,11 @@ class NumpyTranspose(NonFittableMixin, BaseStep):
         return np.array(data_inputs).transpose()
 
 
-class NumpyShapePrinter(NonFittableMixin, BaseStep):
+class NumpyShapePrinter(BaseStep):
 
     def __init__(self, custom_message: str = ""):
         self.custom_message = custom_message
         BaseStep.__init__(self)
-        NonFittableMixin.__init__(self)
 
     def transform(self, data_inputs):
         self._print(data_inputs)
@@ -161,7 +157,7 @@ class NumpyShapePrinter(NonFittableMixin, BaseStep):
         print(self.__class__.__name__ + " (one):", data_input.shape, self.custom_message)
 
 
-class MultiplyByN(NonFittableMixin, BaseStep):
+class MultiplyByN(BaseStep):
     """
     Step to multiply a numpy array.
     Accepts an integer for the number to multiply by.
@@ -177,12 +173,10 @@ class MultiplyByN(NonFittableMixin, BaseStep):
         # outputs => np.array([3])
 
     .. seealso::
-        :class:`~neuraxle.base.NonFittableMixin`,
         :class:`~neuraxle.base.BaseStep`
     """
 
     def __init__(self, multiply_by=1):
-        NonFittableMixin.__init__(self)
         BaseStep.__init__(
             self,
             hyperparams=HyperparameterSamples({
@@ -203,7 +197,7 @@ class MultiplyByN(NonFittableMixin, BaseStep):
         return data_inputs / self.hyperparams['multiply_by']
 
 
-class AddN(NonFittableMixin, BaseStep):
+class AddN(BaseStep):
     """
     Step to add a scalar to a numpy array.
     Accepts an integer for the number to add to every data inputs.
@@ -219,12 +213,10 @@ class AddN(NonFittableMixin, BaseStep):
         # outputs => np.array([2])
 
     .. seealso::
-        :class:`~neuraxle.base.NonFittableMixin`,
         :class:`~neuraxle.base.BaseStep`
     """
 
     def __init__(self, add=1):
-        NonFittableMixin.__init__(self)
         BaseStep.__init__(
             self,
             hyperparams=HyperparameterSamples({
@@ -245,7 +237,7 @@ class AddN(NonFittableMixin, BaseStep):
         return data_inputs - self.hyperparams['add']
 
 
-class Sum(NonFittableMixin, BaseStep):
+class Sum(BaseStep):
     """
     Step sum numpy array using np.sum.
 
@@ -261,12 +253,10 @@ class Sum(NonFittableMixin, BaseStep):
         # outputs => 6)
 
     .. seealso::
-        :class:`NonFittableMixin`,
         :class:`BaseStep`
     """
 
     def __init__(self, axis):
-        NonFittableMixin.__init__(self)
         BaseStep.__init__(self)
         self.axis = axis
 
@@ -278,7 +268,7 @@ class Sum(NonFittableMixin, BaseStep):
         return data_inputs
 
 
-class OneHotEncoder(NonFittableMixin, BaseStep):
+class OneHotEncoder(BaseStep):
     """
     Step to one hot a set of columns.
     Accepts Integer Columns and converts it ot a one_hot.
@@ -350,7 +340,7 @@ class ToNumpy(ForceHandleMixin, BaseStep):
         return data_container.to_numpy(), context
 
 
-class NumpyReshape(NonFittableMixin, BaseStep):
+class NumpyReshape(BaseStep):
     """
     Reshape numpy array in data inputs.
 
@@ -362,13 +352,11 @@ class NumpyReshape(NonFittableMixin, BaseStep):
        assert np.array_equal(outputs, np.array([[1],[0],[3]]))
 
     .. seealso::
-        :class:`NonFittableMixin`
         :class:`BaseStep`
     """
 
     def __init__(self, new_shape):
         BaseStep.__init__(self)
-        NonFittableMixin.__init__(self)
         self.new_shape = new_shape
 
     def transform(self, data_inputs):

--- a/neuraxle/steps/output_handlers.py
+++ b/neuraxle/steps/output_handlers.py
@@ -23,7 +23,7 @@ You can find here output handlers steps that changes especially the data outputs
     project, visit https://www.umaneo.com/ for more information on Umaneo Technologies Inc.
 
 """
-from neuraxle.base import ExecutionContext, BaseStep, MetaStepMixin, ForceHandleOnlyMixin
+from neuraxle.base import ExecutionContext, BaseStep, MetaStepMixin, ForceHandleOnlyMixin, _FittableStep
 from neuraxle.data_container import DataContainer
 
 

--- a/neuraxle/steps/sklearn.py
+++ b/neuraxle/steps/sklearn.py
@@ -29,14 +29,14 @@ from typing import Any
 from sklearn.base import BaseEstimator
 from sklearn.linear_model import Ridge
 
-from neuraxle.base import BaseStep
+from neuraxle.base import BaseStep, _FittableStep
 from neuraxle.hyperparams.distributions import LogUniform, Boolean
 from neuraxle.hyperparams.space import HyperparameterSpace, HyperparameterSamples
 from neuraxle.steps.numpy import NumpyTranspose
 from neuraxle.union import ModelStacking
 
 
-class SKLearnWrapper(BaseStep):
+class SKLearnWrapper(_FittableStep, BaseStep):
     def __init__(
             self,
             wrapped_sklearn_predictor,

--- a/neuraxle/union.py
+++ b/neuraxle/union.py
@@ -27,7 +27,7 @@ This module contains steps to perform various feature unions and model stacking,
 from joblib import Parallel, delayed
 
 from neuraxle.base import BaseStep, TruncableSteps, NamedTupleList, Identity, ExecutionContext, DataContainer, \
-    NonFittableMixin, ForceHandleOnlyMixin
+    ForceHandleOnlyMixin
 from neuraxle.steps.numpy import NumpyConcatenateInnerFeatures
 
 
@@ -58,7 +58,7 @@ class FeatureUnion(ForceHandleOnlyMixin, TruncableSteps):
     def __init__(
             self,
             steps_as_tuple: NamedTupleList,
-            joiner: NonFittableMixin = NumpyConcatenateInnerFeatures(),
+            joiner: BaseStep = NumpyConcatenateInnerFeatures(),
             n_jobs: int = None,
             backend: str = "threading",
             cache_folder_when_no_handle: str = None

--- a/neuraxle/union.py
+++ b/neuraxle/union.py
@@ -27,11 +27,11 @@ This module contains steps to perform various feature unions and model stacking,
 from joblib import Parallel, delayed
 
 from neuraxle.base import BaseStep, TruncableSteps, NamedTupleList, Identity, ExecutionContext, DataContainer, \
-    ForceHandleOnlyMixin
+    ForceHandleOnlyMixin, _FittableStep
 from neuraxle.steps.numpy import NumpyConcatenateInnerFeatures
 
 
-class FeatureUnion(ForceHandleOnlyMixin, TruncableSteps):
+class FeatureUnion(ForceHandleOnlyMixin, _FittableStep, TruncableSteps):
     """
     Parallelize the union of many pipeline steps.
 
@@ -72,6 +72,7 @@ class FeatureUnion(ForceHandleOnlyMixin, TruncableSteps):
         """
         steps_as_tuple.append(('joiner', joiner))
         TruncableSteps.__init__(self, steps_as_tuple)
+        _FittableStep.__init__(self)
         self.n_jobs = n_jobs
         self.backend = backend
         ForceHandleOnlyMixin.__init__(self, cache_folder=cache_folder_when_no_handle)

--- a/testing/api/test_flask.py
+++ b/testing/api/test_flask.py
@@ -22,7 +22,7 @@ Tests for Flask.
 import numpy as np
 
 from neuraxle.rest.flask import JSONDataResponseEncoder, JSONDataBodyDecoder, FlaskRestApiWrapper
-from neuraxle.base import BaseStep, NonFittableMixin
+from neuraxle.base import BaseStep
 
 
 def setup_api():
@@ -52,7 +52,7 @@ def setup_api():
                 'predictions': np.array(data_inputs).tolist()
             }
 
-    class Multiplier(NonFittableMixin, BaseStep):
+    class Multiplier(BaseStep):
         def transform(self, data_inputs):
             return 2 * data_inputs
 

--- a/testing/hyperparams/test_get_set_hyperparams.py
+++ b/testing/hyperparams/test_get_set_hyperparams.py
@@ -1,4 +1,4 @@
-from neuraxle.base import MetaStepMixin, BaseStep, NonFittableMixin, NonTransformableMixin
+from neuraxle.base import MetaStepMixin, BaseStep, NonTransformableMixin
 from neuraxle.hyperparams.distributions import RandInt, Boolean
 from neuraxle.hyperparams.space import HyperparameterSpace, HyperparameterSamples
 from neuraxle.steps.loop import StepClonerForEachDataInput
@@ -22,7 +22,7 @@ HYPE_SAMPLE = HyperparameterSamples({
 })
 
 
-class SomeMetaStepMixin(NonTransformableMixin, NonFittableMixin, MetaStepMixin, BaseStep):
+class SomeMetaStepMixin(NonTransformableMixin, MetaStepMixin, BaseStep):
     pass
 
 

--- a/testing/mocks/step_mocks.py
+++ b/testing/mocks/step_mocks.py
@@ -1,4 +1,4 @@
-from neuraxle.base import BaseStep, TruncableSteps, NonFittableMixin, MetaStepMixin
+from neuraxle.base import BaseStep, TruncableSteps, MetaStepMixin
 from neuraxle.hyperparams.distributions import LogUniform, Quantized, RandInt, Boolean
 from neuraxle.hyperparams.space import HyperparameterSpace, HyperparameterSamples
 
@@ -30,10 +30,9 @@ AN_INPUT = "I am an input"
 AN_EXPECTED_OUTPUT = "I am an expected output"
 
 
-class SomeStep(NonFittableMixin, BaseStep):
+class SomeStep(BaseStep):
     def __init__(self, hyperparams_space: HyperparameterSpace = None, output=AN_EXPECTED_OUTPUT):
         BaseStep.__init__(self, hyperparams=None, hyperparams_space=hyperparams_space)
-        NonFittableMixin.__init__(self)
         self.output = output
 
     def transform(self, data_inputs):
@@ -82,12 +81,6 @@ class SomeTruncableStep(TruncableSteps):
         pass
 
 
-class SomeSplitStep(NonFittableMixin, BaseStep):
-    def fit(self, data_inputs, expected_outputs=None) -> 'NonFittableMixin':
-        pass
-
-    def fit_transform(self, data_inputs, expected_outputs=None):
-        pass
-
+class SomeSplitStep(BaseStep):
     def transform(self, data_inputs):
         pass

--- a/testing/steps/test_output_transformer_wrapper.py
+++ b/testing/steps/test_output_transformer_wrapper.py
@@ -2,21 +2,20 @@ from typing import Tuple, Any
 
 from py._path.local import LocalPath
 
-from neuraxle.base import BaseStep, NonFittableMixin, ExecutionContext, ExecutionMode
+from neuraxle.base import BaseStep, ExecutionContext, ExecutionMode
 from neuraxle.data_container import DataContainer
 from neuraxle.hyperparams.space import HyperparameterSamples, HyperparameterSpace
 from neuraxle.pipeline import Pipeline
 from neuraxle.steps.output_handlers import InputAndOutputTransformerMixin
 
 
-class MultiplyBy2OutputTransformer(NonFittableMixin, InputAndOutputTransformerMixin, BaseStep):
+class MultiplyBy2OutputTransformer(InputAndOutputTransformerMixin, BaseStep):
     def __init__(
             self,
             hyperparams: HyperparameterSamples = None,
             hyperparams_space: HyperparameterSpace = None,
             name: str = None
     ):
-        NonFittableMixin.__init__(self)
         BaseStep.__init__(self, hyperparams, hyperparams_space, name)
         InputAndOutputTransformerMixin.__init__(self)
 

--- a/testing/test_base_transformer.py
+++ b/testing/test_base_transformer.py
@@ -1,0 +1,2 @@
+def test_base_transformer_transform():
+    pass

--- a/testing/test_checkpoints.py
+++ b/testing/test_checkpoints.py
@@ -61,8 +61,8 @@ def test_resumable_pipeline_with_checkpoint_fit_transform_should_resume_saved_ch
 
     pipeline, outputs = test_case.pipeline.fit_transform([0, 1], [1, 2])
 
-    assert test_case.tape_transform_step1.data == []
-    assert test_case.tape_fit_step1.data == []
+    assert test_case.tape_transform_step1.data == [[0, 1]]
+    assert test_case.tape_fit_step1.data == [([0, 1], [1, 2])]
     assert test_case.tape_fit_step2.data == [([0, 1], [1, 2])]
     assert test_case.tape_transform_step2.data == [[0, 1]]
 
@@ -73,7 +73,7 @@ def test_resumable_pipeline_with_checkpoint_transform_should_resume_saved_checkp
 
     outputs = test_case.pipeline.transform([0, 1])
 
-    assert test_case.tape_transform_step1.data == []
+    assert test_case.tape_transform_step1.data == [[0, 1]]
     assert test_case.tape_fit_step2.data == []
     assert test_case.tape_transform_step2.data == [[0, 1]]
 
@@ -84,8 +84,8 @@ def test_resumable_pipeline_with_checkpoint_fit_should_resume_saved_checkpoints(
 
     pipeline = test_case.pipeline.fit([0, 1], [1, 2])
 
-    assert test_case.tape_fit_step1.data == []
-    assert test_case.tape_transform_step1.data == []
+    assert test_case.tape_fit_step1.data == [([0, 1], [1, 2])]
+    assert test_case.tape_transform_step1.data == [[0, 1]]
     assert test_case.tape_transform_step2.data == []
     assert test_case.tape_fit_step2.data == [([0, 1], [1, 2])]
 

--- a/testing/test_issue_bug.py
+++ b/testing/test_issue_bug.py
@@ -1,0 +1,39 @@
+import numpy as np
+from sklearn.metrics import mean_squared_error
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import LinearSVC
+
+from neuraxle.hyperparams.distributions import RandInt
+from neuraxle.hyperparams.space import HyperparameterSpace
+from neuraxle.metaopt.auto_ml import AutoML, InMemoryHyperparamsRepository, \
+    ValidationSplitter
+from neuraxle.metaopt.callbacks import MetricCallback, ScoringCallback
+from neuraxle.pipeline import Pipeline
+from neuraxle.steps.sklearn import SKLearnWrapper
+
+
+def test_issue():
+    data_inputs = np.random.randint(0, 100, (100, 3))
+    expected_outputs = np.random.randint(0, 3, 100)
+
+    p = Pipeline([
+        SKLearnWrapper(StandardScaler()),
+        SKLearnWrapper(LinearSVC(),
+                       HyperparameterSpace({'C': RandInt(0, 10000)})),
+    ])
+
+    auto_ml = AutoML(
+        p,
+        validation_splitter=ValidationSplitter(0.20),
+        refit_trial=True,
+        n_trials=10,
+        epochs=10,
+        cache_folder_when_no_handle='cache',
+        scoring_callback=ScoringCallback(mean_squared_error, higher_score_is_better=False),
+        callbacks=[MetricCallback('mse', metric_function=mean_squared_error,
+                                  higher_score_is_better=False)],
+        hyperparams_repository=InMemoryHyperparamsRepository(
+            cache_folder='cache')
+    )
+
+    random_search = auto_ml.fit(data_inputs, expected_outputs)

--- a/testing/test_metastep_mixin.py
+++ b/testing/test_metastep_mixin.py
@@ -1,10 +1,10 @@
 from neuraxle.pipeline import Pipeline
 
-from neuraxle.base import MetaStepMixin, BaseStep, NonFittableMixin, NonTransformableMixin
+from neuraxle.base import MetaStepMixin, BaseStep, NonTransformableMixin
 from neuraxle.union import Identity
 
 
-class SomeMetaStep(NonFittableMixin, MetaStepMixin, BaseStep):
+class SomeMetaStep(MetaStepMixin, BaseStep):
     def __init__(self, wrapped: BaseStep):
         BaseStep.__init__(self)
         MetaStepMixin.__init__(self, wrapped)

--- a/testing/test_pickle_checkpoint_step.py
+++ b/testing/test_pickle_checkpoint_step.py
@@ -26,7 +26,6 @@ import numpy as np
 from py._path.local import LocalPath
 
 from neuraxle.base import ExecutionContext, Identity
-from neuraxle.base import NonFittableMixin
 from neuraxle.checkpoints import DefaultCheckpoint
 from neuraxle.data_container import DataContainer
 from neuraxle.hyperparams.space import HyperparameterSamples
@@ -41,7 +40,7 @@ expected_outputs = np.array([2, 3])
 expected_rehashed_data_inputs = ['44f9d6dd8b6ccae571ca04525c3eaffa', '898a67b2f5eeae6393ca4b3162ba8e3d']
 
 
-class DifferentCallbackStep(NonFittableMixin, BaseCallbackStep):
+class DifferentCallbackStep(BaseCallbackStep):
     def transform(self, data_inputs):
         self._callback(data_inputs)
         return data_inputs

--- a/testing/test_pipeline_setup_teardown.py
+++ b/testing/test_pipeline_setup_teardown.py
@@ -54,6 +54,7 @@ def test_transform_should_not_setup_pipeline_and_steps():
     p = SomePipeline([
         step_setup
     ])
+    assert not p.is_initialized
 
     p.transform([1])
 

--- a/testing/test_step_saving.py
+++ b/testing/test_step_saving.py
@@ -4,7 +4,7 @@ import numpy as np
 from joblib import dump
 from py._path.local import LocalPath
 
-from neuraxle.base import BaseStep, TruncableJoblibStepSaver, NonFittableMixin
+from neuraxle.base import BaseStep, TruncableJoblibStepSaver
 from neuraxle.checkpoints import DefaultCheckpoint
 from neuraxle.hyperparams.space import HyperparameterSamples
 from neuraxle.pipeline import ResumablePipeline


### PR DESCRIPTION
# What it is

My pull request does: remove the need to use NonFittableMixin. Make BaseStep not fit by default, and extract all handler methods logic inside _FittableStep, and _TransformerStep. 

# Example usage

A non fittable step : 

```python 
class SomeTransformerStep(BaseStep):
    def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
        # facultative. transform override only is enough
        data_container.set_data_inputs(self(data_container.data_inputs))
        return data_container

    def transform(self, data_inputs):
        return data_inputs

SomeTransformerStep()(np.array([0,1]) # this will call transform method !
```

A fittable step : 

```python 
class SomeFitttableStep(_FittableStep, BaseStep):
    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
        # facultative. only fit, and transform implementation required
        return self

    def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
        # facultative. only fit, and transform implementation required
        data_container.set_data_inputs(self(data_container.data_inputs))
        return data_container

    def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
        # facultative. only fit, and transform implementation required
        data_container.set_data_inputs(self(data_container.data_inputs))
        return self, data_container

    def fit(self, data_inputs, expected_outputs) -> '_FittableStep':
        return self

    def transform(self, data_inputs):
        return data_inputs
```
