### PR TITLE
Implement Input And Output Transformer Wrapper

### DIFF
--- a/neuraxle/steps/output_handlers.py
+++ b/neuraxle/steps/output_handlers.py
@@ -23,6 +23,8 @@ You can find here output handlers steps that changes especially the data outputs
     project, visit https://www.umaneo.com/ for more information on Umaneo Technologies Inc.
 
 """
+import copy
+
 from neuraxle.base import ExecutionContext, BaseStep, MetaStep, ForceHandleOnlyMixin
 from neuraxle.data_container import DataContainer
 
@@ -48,15 +50,19 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
         :rtype: DataContainer
         """
         new_expected_outputs_data_container = self.wrapped.handle_transform(
-            DataContainer(data_inputs=data_container.expected_outputs, current_ids=data_container.current_ids,
-                          expected_outputs=None),
+            DataContainer(
+                data_inputs=data_container.expected_outputs,
+                current_ids=data_container.current_ids,
+                expected_outputs=None
+            ),
             context
         )
         data_container.set_expected_outputs(new_expected_outputs_data_container.data_inputs)
 
         return data_container
 
-    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (BaseStep, DataContainer):
+    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (
+    BaseStep, DataContainer):
         """
         Handle fit by passing expected outputs to the wrapped step fit method.
 
@@ -67,14 +73,18 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
         :rtype: (BaseStep, DataContainer)
         """
         self.wrapped = self.wrapped.handle_fit(
-            DataContainer(data_inputs=data_container.expected_outputs, current_ids=data_container.current_ids,
-                          expected_outputs=None),
+            DataContainer(
+                data_inputs=data_container.expected_outputs,
+                current_ids=data_container.current_ids,
+                expected_outputs=None
+            ),
             context
         )
 
         return self, data_container
 
-    def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (BaseStep, DataContainer):
+    def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (
+    BaseStep, DataContainer):
         """
         Handle fit transform by passing expected outputs to the wrapped step fit method.
         Update the expected outputs with the outputs.
@@ -86,8 +96,11 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
         :rtype: (BaseStep, DataContainer)
         """
         self.wrapped, new_expected_outputs_data_container = self.wrapped.handle_fit_transform(
-            DataContainer(data_inputs=data_container.expected_outputs, current_ids=data_container.current_ids,
-                          expected_outputs=None),
+            DataContainer(
+                data_inputs=data_container.expected_outputs,
+                current_ids=data_container.current_ids,
+                expected_outputs=None
+            ),
             context
         )
         data_container.set_expected_outputs(new_expected_outputs_data_container.data_inputs)
@@ -105,8 +118,11 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
         :rtype: DataContainer
         """
         new_expected_outputs_data_container = self.wrapped.handle_inverse_transform(
-            DataContainer(data_inputs=data_container.expected_outputs, current_ids=data_container.current_ids,
-                          expected_outputs=None),
+            DataContainer(
+                data_inputs=data_container.expected_outputs,
+                current_ids=data_container.current_ids,
+                expected_outputs=None
+            ),
             context.push(self.wrapped)
         )
 
@@ -114,6 +130,128 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
 
         current_ids = self.hash(data_container)
         data_container.set_current_ids(current_ids)
+
+        return data_container
+
+
+class InputAndOutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
+    """
+    Wrapper step to transform both data inputs, and expected output at the same.
+    It sends the data_inputs, and the expected_outputs to the wrapped step so that it can transform them.
+
+    .. seealso::
+        :class:`~neuraxle.base.BaseStep`,
+        :class:`~neuraxle.base.ForceHandleOnlyMixin`
+    """
+
+    def __init__(self, wrapped, cache_folder_when_no_handle=None):
+        MetaStep.__init__(self, wrapped)
+        ForceHandleOnlyMixin.__init__(self, cache_folder_when_no_handle)
+
+    def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        """
+        Handle transform by passing data_inputs, and expected outputs to the wrapped step transform method.
+        Update the expected outputs with the outputs.
+
+        :param context: execution context
+        :param data_container:
+        :return: data container
+        :rtype: DataContainer
+        """
+        output_data_container = self.wrapped.handle_transform(
+            DataContainer(
+                data_inputs=(data_container.data_inputs, data_container.expected_outputs),
+                current_ids=data_container.current_ids,
+                expected_outputs=None
+            ),
+            context
+        )
+
+        self._set_data_inputs_and_expected_outputs(data_container, output_data_container)
+
+        return data_container
+
+    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (BaseStep, DataContainer):
+        """
+        Handle fit by passing the data inputs, and the expected outputs to the wrapped step fit method.
+
+        :param context: execution context
+        :type context: ExecutionContext
+        :param data_container: data container to fit on
+        :return: self, data container
+        :rtype: (BaseStep, DataContainer)
+        """
+        self.wrapped = self.wrapped.handle_fit(
+            DataContainer(
+                data_inputs=(copy.copy(data_container.data_inputs), copy.copy(data_container.expected_outputs)),
+                current_ids=data_container.current_ids,
+                expected_outputs=None
+            ),
+            context
+        )
+
+        return self, data_container
+
+    def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (BaseStep, DataContainer):
+        """
+        Handle fit transform by passing the data inputs, and the expected outputs to the wrapped step fit method.
+        Update the expected outputs with the outputs.
+
+        :param context: execution context
+        :type context: ExecutionContext
+        :param data_container: data container to fit on
+        :return: self, data container
+        :rtype: (BaseStep, DataContainer)
+        """
+        self.wrapped, output_data_container = self.wrapped.handle_fit_transform(
+            DataContainer(
+                data_inputs=(data_container.data_inputs, data_container.expected_outputs),
+                current_ids=data_container.current_ids,
+                expected_outputs=None
+            ),
+            context
+        )
+        self._set_data_inputs_and_expected_outputs(data_container, output_data_container)
+
+        return self, data_container
+
+    def handle_inverse_transform(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        """
+        Handle inverse transform by passing the data inputs, and the expected outputs to the wrapped step inverse transform method.
+        Update the expected outputs with the outputs.
+
+        :param context: execution context
+        :param data_container:
+        :return: data container
+        :rtype: DataContainer
+        """
+        output_data_container = self.wrapped.handle_inverse_transform(
+            DataContainer(
+                data_inputs=(data_container.data_inputs, data_container.expected_outputs),
+                current_ids=data_container.current_ids,
+                expected_outputs=None
+            ),
+            context.push(self.wrapped)
+        )
+
+        self._set_data_inputs_and_expected_outputs(data_container, output_data_container)
+
+        current_ids = self.hash(data_container)
+        data_container.set_current_ids(current_ids)
+
+        return data_container
+
+    def _set_data_inputs_and_expected_outputs(self, data_container, output_data_container) -> DataContainer:
+        data_inputs, expected_outputs = output_data_container.data_inputs
+        if len(data_inputs) != len(expected_outputs):
+            raise AssertionError('InputAndOutputTransformerWrapper: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs.')
+
+        if len(output_data_container.current_ids) != len(data_inputs):
+            raise AssertionError('InputAndOutputTransformerWrapper: Caching broken because there is a different len of current ids, and data inputs.'
+                                 'Please resample the current ids using handler methods, or create new ones by setting the wrapped step saver to HashlibMd5ValueHasher using the BaseStep.set_savers method.')
+
+        data_container.set_data_inputs(data_inputs)
+        data_container.set_expected_outputs(expected_outputs)
 
         return data_container
 
@@ -167,4 +305,3 @@ class InputAndOutputTransformerMixin:
         data_container.set_expected_outputs(new_expected_outputs)
 
         return new_self, data_container
-

--- a/testing/test_output_transformer_wrapper.py
+++ b/testing/test_output_transformer_wrapper.py
@@ -1,11 +1,40 @@
 import numpy as np
+import pytest
 
-from neuraxle.base import ExecutionContext
+from neuraxle.base import ExecutionContext, BaseTransformer
 from neuraxle.data_container import DataContainer
+from neuraxle.hyperparams.space import HyperparameterSamples
 from neuraxle.pipeline import Pipeline
 from neuraxle.steps.misc import FitCallbackStep, TapeCallbackFunction
 from neuraxle.steps.numpy import MultiplyByN
-from neuraxle.steps.output_handlers import OutputTransformerWrapper
+from neuraxle.steps.output_handlers import OutputTransformerWrapper, InputAndOutputTransformerWrapper
+
+
+class MultiplyByNInputAndOutput(BaseTransformer):
+    def __init__(self, multiply_by=1):
+        super().__init__(hyperparams=HyperparameterSamples({'multiply_by': multiply_by}))
+
+    def transform(self, data_inputs):
+        data_inputs, expected_outputs = data_inputs
+
+        if not isinstance(data_inputs, np.ndarray):
+            data_inputs = np.array(data_inputs)
+
+        if not isinstance(expected_outputs, np.ndarray):
+            expected_outputs = np.array(expected_outputs)
+
+        return data_inputs * self.hyperparams['multiply_by'], expected_outputs * self.hyperparams['multiply_by']
+
+    def inverse_transform(self, data_inputs):
+        data_inputs, expected_outputs = data_inputs
+
+        if not isinstance(data_inputs, np.ndarray):
+            data_inputs = np.array(data_inputs)
+
+        if not isinstance(expected_outputs, np.ndarray):
+            expected_outputs = np.array(expected_outputs)
+
+        return data_inputs / self.hyperparams['multiply_by'], expected_outputs / self.hyperparams['multiply_by']
 
 
 def test_output_transformer_wrapper_should_fit_with_data_inputs_and_expected_outputs_as_data_inputs():
@@ -48,6 +77,86 @@ def test_output_transformer_wrapper_should_transform_with_data_inputs_and_expect
 
     assert np.array_equal(data_container.data_inputs, data_inputs)
     assert np.array_equal(data_container.expected_outputs, expected_outputs * 2)
+
+
+def test_input_and_output_transformer_wrapper_should_fit_with_data_inputs_and_expected_outputs_as_data_inputs():
+    tape = TapeCallbackFunction()
+    p = InputAndOutputTransformerWrapper(FitCallbackStep(tape))
+    data_inputs, expected_outputs = _create_data_source((10, 10))
+
+    p.fit(data_inputs, expected_outputs)
+
+    assert np.array_equal(tape.data[0][0][0], data_inputs)
+    assert np.array_equal(tape.data[0][0][1], expected_outputs)
+
+
+def test_input_and_output_transformer_wrapper_should_fit_transform_with_data_inputs_and_expected_outputs():
+    tape = TapeCallbackFunction()
+    p = InputAndOutputTransformerWrapper(Pipeline([MultiplyByNInputAndOutput(2), FitCallbackStep(tape)]))
+    data_inputs, expected_outputs = _create_data_source((10, 10))
+
+    p, data_container = p.handle_fit_transform(DataContainer(
+        data_inputs=data_inputs,
+        expected_outputs=expected_outputs
+    ), ExecutionContext())
+
+    assert np.array_equal(data_container.data_inputs, data_inputs * 2)
+    assert np.array_equal(data_container.expected_outputs, expected_outputs * 2)
+    assert np.array_equal(tape.data[0][0][0], data_inputs * 2)
+    assert np.array_equal(tape.data[0][0][1], expected_outputs * 2)
+
+
+def test_input_and_output_transformer_wrapper_should_transform_with_data_inputs_and_expected_outputs():
+    p = InputAndOutputTransformerWrapper(MultiplyByNInputAndOutput(2))
+    data_inputs, expected_outputs = _create_data_source((10, 10))
+
+    data_container = p.handle_transform(DataContainer(
+        data_inputs=data_inputs,
+        expected_outputs=expected_outputs
+    ), ExecutionContext())
+
+    assert np.array_equal(data_container.data_inputs, data_inputs * 2)
+    assert np.array_equal(data_container.expected_outputs, expected_outputs * 2)
+
+
+class ChangeLenDataInputs(BaseTransformer):
+    def __init__(self):
+        super().__init__()
+
+    def transform(self, data_inputs):
+        data_inputs, expected_outputs = data_inputs
+        return data_inputs[0:int(len(data_inputs) / 2)], expected_outputs
+
+
+class ChangeLenDataInputsAndExpectedOutputs(BaseTransformer):
+    def __init__(self):
+        super().__init__()
+
+    def transform(self, data_inputs):
+        data_inputs, expected_outputs = data_inputs
+        return data_inputs[0:int(len(data_inputs) / 2)], expected_outputs
+
+
+def test_input_and_output_transformer_wrapper_should_not_return_a_different_amount_of_data_inputs_and_expected_outputs():
+    with pytest.raises(AssertionError):
+        p = InputAndOutputTransformerWrapper(ChangeLenDataInputs())
+        data_inputs, expected_outputs = _create_data_source((10, 10))
+
+        p.handle_transform(DataContainer(
+            data_inputs=data_inputs,
+            expected_outputs=expected_outputs
+        ), ExecutionContext())
+
+
+def test_input_and_output_transformer_wrapper_should_raise_an_assertion_error_if_current_ids_have_not_been_resampled_correctly():
+    with pytest.raises(AssertionError):
+        p = InputAndOutputTransformerWrapper(ChangeLenDataInputsAndExpectedOutputs())
+        data_inputs, expected_outputs = _create_data_source((10, 10))
+
+        p.handle_transform(DataContainer(
+            data_inputs=data_inputs,
+            expected_outputs=expected_outputs
+        ), ExecutionContext())
 
 
 def _create_data_source(shape):


### PR DESCRIPTION
# What it is

- Add the InputAndOutputTransformerWrapper that sends data_inputs, and expected_outputs as a tuple to the wrapped step. 
- Add a "value hyperparameter" hasher to create new ids using value hashing if needed  : HashlibMd5ValueHasher. This is particularly useful if the user wants to change the len of the data inputs without having to loop on the data container inside handler methods (in order to resample the ids correctly). Note that the summary id makes it ok for us to do that. 

# Example usage

Here is how you can use this new code as a end user: 

```python 
p = InputAndOutputTransformerWrapper(
      ChangeLenDataInputsAndExpectedOutputs().set_hashers([HashlibMd5ValueHasher()])
)

p.handle_transform(DataContainer(
       data_inputs=data_inputs,
       expected_outputs=expected_outputs
), ExecutionContext())

```

