### PR TITLE
Fix Output Handlers Hashing

### DIFF
--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -1746,6 +1746,10 @@ class _HasHashers(ABC):
 
         self.hashers: List[BaseHasher] = hashers
 
+    def set_hashers(self, hashers: List[BaseHasher]) -> '_HasHashers':
+        self.hashers: List[BaseHasher] = hashers
+        return self
+
     def summary_hash(self, data_container: DataContainer) -> str:
         """
         Hash data inputs, current ids, and hyperparameters together using self.hashers.

--- a/neuraxle/steps/output_handlers.py
+++ b/neuraxle/steps/output_handlers.py
@@ -150,7 +150,7 @@ class _DidProcessInputOutputHandlerMixin:
         di, eo = data_container.data_inputs
         if len(di) != len(eo):
             raise AssertionError(
-                '{}: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs.'.format(
+                '{}: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs, or otherwise create your own handler methods to do more funky things.'.format(
                     self.name))
 
         data_container.set_data_inputs(data_inputs=di)

--- a/neuraxle/steps/output_handlers.py
+++ b/neuraxle/steps/output_handlers.py
@@ -135,7 +135,9 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
     def _set_expected_outputs(self, data_container, new_expected_outputs_data_container) -> DataContainer:
         if len(data_container.data_inputs) != len(data_container.expected_outputs):
             raise AssertionError(
-                'OutputTransformerWrapper: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs.')
+                'OutputTransformerWrapper: Found different len for data inputs, and expected outputs. '
+                'Please return the same the same amount of data inputs, and expected outputs, '
+                'or otherwise create your own handler methods to do more funky things.')
 
         data_container.set_expected_outputs(new_expected_outputs_data_container.data_inputs)
         data_container.set_current_ids(new_expected_outputs_data_container.current_ids)

--- a/neuraxle/steps/output_handlers.py
+++ b/neuraxle/steps/output_handlers.py
@@ -220,7 +220,10 @@ class InputAndOutputTransformerWrapper(_DidProcessInputOutputHandlerMixin, Force
             context
         )
 
-        return self, data_container
+        data_container.set_data_inputs((data_container.data_inputs, data_container.expected_outputs))
+        data_container.set_expected_outputs(expected_outputs=None)
+
+        return self
 
     def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (BaseStep, DataContainer):
         """
@@ -265,7 +268,7 @@ class InputAndOutputTransformerWrapper(_DidProcessInputOutputHandlerMixin, Force
         current_ids = self.hash(data_container)
         data_container.set_current_ids(current_ids)
 
-        return data_container
+        return output_data_container
 
 
 class InputAndOutputTransformerMixin(_DidProcessInputOutputHandlerMixin):
@@ -286,7 +289,7 @@ class InputAndOutputTransformerMixin(_DidProcessInputOutputHandlerMixin):
         data_container.set_data_inputs((new_data_inputs, new_expected_outputs))
         return data_container
 
-    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
+    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> 'BaseStep':
         """
         Handle transform by fitting the step,
         and updating the data inputs, and expected outputs inside the data container.
@@ -296,7 +299,9 @@ class InputAndOutputTransformerMixin(_DidProcessInputOutputHandlerMixin):
         :return:
         """
         new_self = self.fit((data_container.data_inputs, data_container.expected_outputs), None)
-        return new_self, data_container
+        data_container.set_data_inputs((data_container.data_inputs, data_container.expected_outputs))
+        data_container.set_expected_outputs(expected_outputs=None)
+        return new_self
 
     def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
         """

--- a/neuraxle/steps/output_handlers.py
+++ b/neuraxle/steps/output_handlers.py
@@ -24,8 +24,10 @@ You can find here output handlers steps that changes especially the data outputs
 
 """
 import copy
+from abc import ABC
+from typing import List
 
-from neuraxle.base import ExecutionContext, BaseStep, MetaStep, ForceHandleOnlyMixin
+from neuraxle.base import ExecutionContext, BaseStep, MetaStep, ForceHandleOnlyMixin, BaseHasher
 from neuraxle.data_container import DataContainer
 
 
@@ -62,7 +64,7 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
         return data_container
 
     def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (
-    BaseStep, DataContainer):
+            BaseStep, DataContainer):
         """
         Handle fit by passing expected outputs to the wrapped step fit method.
 
@@ -84,7 +86,7 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
         return self, data_container
 
     def _fit_transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (
-    BaseStep, DataContainer):
+            BaseStep, DataContainer):
         """
         Handle fit transform by passing expected outputs to the wrapped step fit method.
         Update the expected outputs with the outputs.
@@ -132,7 +134,8 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
 
     def _set_expected_outputs(self, data_container, new_expected_outputs_data_container) -> DataContainer:
         if len(data_container.data_inputs) != len(data_container.expected_outputs):
-            raise AssertionError('OutputTransformerWrapper: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs.')
+            raise AssertionError(
+                'OutputTransformerWrapper: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs.')
 
         data_container.set_expected_outputs(new_expected_outputs_data_container.data_inputs)
         data_container.set_current_ids(new_expected_outputs_data_container.current_ids)
@@ -140,7 +143,28 @@ class OutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
         return data_container
 
 
-class InputAndOutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
+class _DidProcessInputOutputHandlerMixin:
+    def _did_process(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
+        di, eo = data_container.data_inputs
+        if len(di) != len(eo):
+            raise AssertionError(
+                '{}: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs.'.format(
+                    self.name))
+
+        data_container.set_data_inputs(data_inputs=di)
+        data_container.set_expected_outputs(expected_outputs=eo)
+
+        data_container = super()._did_process(data_container, context)
+
+        if len(data_container.current_ids) != len(data_container.data_inputs):
+            raise AssertionError(
+                '{}: Caching broken because there is a different len of current ids, and data inputs. Please use InputAndOutputTransformerWrapper if you plan to change the len of the data inputs.'.format(
+                    self.name))
+
+        return data_container
+
+
+class InputAndOutputTransformerWrapper(_DidProcessInputOutputHandlerMixin, ForceHandleOnlyMixin, MetaStep):
     """
     Wrapper step to transform both data inputs, and expected output at the same.
     It sends the data_inputs, and the expected_outputs to the wrapped step so that it can transform them.
@@ -150,9 +174,10 @@ class InputAndOutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
         :class:`~neuraxle.base.ForceHandleOnlyMixin`
     """
 
-    def __init__(self, wrapped, cache_folder_when_no_handle=None):
-        MetaStep.__init__(self, wrapped)
+    def __init__(self, wrapped, hashers: List[BaseHasher] = None, cache_folder_when_no_handle=None):
+        MetaStep.__init__(self, wrapped, hashers=hashers)
         ForceHandleOnlyMixin.__init__(self, cache_folder_when_no_handle)
+        _DidProcessInputOutputHandlerMixin.__init__(self)
 
     def _transform_data_container(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
         """
@@ -173,11 +198,10 @@ class InputAndOutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
             context
         )
 
-        self._set_data_inputs_and_expected_outputs(data_container, output_data_container)
+        return output_data_container
 
-        return data_container
-
-    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (BaseStep, DataContainer):
+    def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> (
+            BaseStep, DataContainer):
         """
         Handle fit by passing the data inputs, and the expected outputs to the wrapped step fit method.
 
@@ -217,9 +241,7 @@ class InputAndOutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
             ),
             context
         )
-        self._set_data_inputs_and_expected_outputs(data_container, output_data_container)
-
-        return self, data_container
+        return self, output_data_container
 
     def handle_inverse_transform(self, data_container: DataContainer, context: ExecutionContext) -> DataContainer:
         """
@@ -240,29 +262,13 @@ class InputAndOutputTransformerWrapper(ForceHandleOnlyMixin, MetaStep):
             context.push(self.wrapped)
         )
 
-        self._set_data_inputs_and_expected_outputs(data_container, output_data_container)
-
         current_ids = self.hash(data_container)
         data_container.set_current_ids(current_ids)
 
         return data_container
 
-    def _set_data_inputs_and_expected_outputs(self, data_container, output_data_container) -> DataContainer:
-        data_inputs, expected_outputs = output_data_container.data_inputs
-        if len(data_inputs) != len(expected_outputs):
-            raise AssertionError('InputAndOutputTransformerWrapper: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs.')
 
-        if len(output_data_container.current_ids) != len(data_inputs):
-            raise AssertionError('InputAndOutputTransformerWrapper: Caching broken because there is a different len of current ids, and data inputs.'
-                                 'Please resample the current ids using handler methods, or create new ones by setting the wrapped step saver to HashlibMd5ValueHasher using the BaseStep.set_savers method.')
-
-        data_container.set_data_inputs(data_inputs)
-        data_container.set_expected_outputs(expected_outputs)
-
-        return data_container
-
-
-class InputAndOutputTransformerMixin:
+class InputAndOutputTransformerMixin(_DidProcessInputOutputHandlerMixin):
     """
     Base output transformer step that can modify data inputs, and expected_outputs at the same time.
     """
@@ -277,9 +283,7 @@ class InputAndOutputTransformerMixin:
         """
         di_eo = (data_container.data_inputs, data_container.expected_outputs)
         new_data_inputs, new_expected_outputs = self.transform(di_eo)
-
-        self._set_data_inputs_and_expected_outputs(data_container, new_data_inputs, new_expected_outputs)
-
+        data_container.set_data_inputs((new_data_inputs, new_expected_outputs))
         return data_container
 
     def _fit_data_container(self, data_container: DataContainer, context: ExecutionContext) -> ('BaseStep', DataContainer):
@@ -303,19 +307,7 @@ class InputAndOutputTransformerMixin:
         :param data_container:
         :return:
         """
-        new_self, (new_data_inputs, new_expected_outputs) = self.fit_transform((data_container.data_inputs, data_container.expected_outputs), None)
-
-        self._set_data_inputs_and_expected_outputs(data_container, new_data_inputs, new_expected_outputs)
-
+        new_self, (new_data_inputs, new_expected_outputs) = self.fit_transform(
+            (data_container.data_inputs, data_container.expected_outputs), None)
+        data_container.set_data_inputs((new_data_inputs, new_expected_outputs))
         return new_self, data_container
-
-    def _set_data_inputs_and_expected_outputs(self, data_container, new_data_inputs, new_expected_outputs):
-        data_container.set_data_inputs(new_data_inputs)
-        data_container.set_expected_outputs(new_expected_outputs)
-
-        if len(new_data_inputs) != len(new_expected_outputs):
-            raise AssertionError('InputAndOutputTransformerMixin: Found different len for data inputs, and expected outputs. Please return the same the same amount of data inputs, and expected outputs.')
-
-        if len(data_container.current_ids) != len(new_data_inputs):
-            raise AssertionError('InputAndOutputTransformerMixin: Caching broken because there is a different len of current ids, and data inputs. Please use InputAndOutputTransformerWrapper if you plan to change the len of the data inputs.')
-

--- a/testing/test_hashlib_md5_value_hashing.py
+++ b/testing/test_hashlib_md5_value_hashing.py
@@ -1,0 +1,85 @@
+import numpy as np
+from neuraxle.steps.output_handlers import InputAndOutputTransformerMixin, InputAndOutputTransformerWrapper
+
+from neuraxle.data_container import DataContainer
+
+from neuraxle.base import BaseTransformer, HashlibMd5ValueHasher, ExecutionContext
+
+
+class WindowTimeSeries(InputAndOutputTransformerMixin, BaseTransformer):
+    def __init__(self):
+        super().__init__(hashers=[HashlibMd5ValueHasher()])
+        InputAndOutputTransformerMixin.__init__(self)
+
+    def transform(self, data_inputs):
+        di, eo = data_inputs
+        new_di, new_eo = np.array_split(np.array(di), 2)
+        return new_di, new_eo
+
+
+class WindowTimeSeriesForOutputTransformerWrapper(BaseTransformer):
+    def __init__(self):
+        super().__init__()
+
+    def transform(self, data_inputs):
+        di, eo = data_inputs
+        new_di, new_eo = np.array_split(np.array(di), 2)
+        return new_di, new_eo
+
+
+def test_transform_input_and_output_transformer_mixin_with_hashlib_md5_value_hasher():
+    data_container: DataContainer = WindowTimeSeries().handle_transform(
+        data_container=DataContainer(
+            data_inputs=np.array(list(range(10))),
+            expected_outputs=np.array(list(range(10)))
+        ),
+        context=ExecutionContext()
+    )
+
+    assert np.array_equal(data_container.data_inputs, np.array(list(range(0, 5))))
+    assert np.array_equal(data_container.expected_outputs, np.array(list(range(5, 10))))
+
+
+def test_transform_input_and_output_transformer_wrapper_with_hashlib_md5_value_hasher():
+    step = InputAndOutputTransformerWrapper(WindowTimeSeriesForOutputTransformerWrapper()) \
+        .set_hashers([HashlibMd5ValueHasher()])
+
+    data_container = step.handle_transform(
+        data_container=DataContainer(
+            data_inputs=np.array(list(range(10))),
+            expected_outputs=np.array(list(range(10)))
+        ),
+        context=ExecutionContext()
+    )
+
+    assert np.array_equal(data_container.data_inputs, np.array(list(range(0, 5))))
+    assert np.array_equal(data_container.expected_outputs, np.array(list(range(5, 10))))
+
+
+def test_fit_transform_input_and_output_transformer_mixin_with_hashlib_md5_value_hasher():
+    step, data_container = WindowTimeSeries().handle_fit_transform(
+        data_container=DataContainer(
+            data_inputs=np.array(list(range(10))),
+            expected_outputs=np.array(list(range(10)))
+        ),
+        context=ExecutionContext()
+    )
+
+    assert np.array_equal(data_container.data_inputs, np.array(list(range(0, 5))))
+    assert np.array_equal(data_container.expected_outputs, np.array(list(range(5, 10))))
+
+
+def test_fit_transform_input_and_output_transformer_wrapper_with_hashlib_md5_value_hasher():
+    step = InputAndOutputTransformerWrapper(WindowTimeSeriesForOutputTransformerWrapper()) \
+        .set_hashers([HashlibMd5ValueHasher()])
+
+    step, data_container = step.handle_fit_transform(
+        data_container=DataContainer(
+            data_inputs=np.array(list(range(10))),
+            expected_outputs=np.array(list(range(10)))
+        ),
+        context=ExecutionContext()
+    )
+
+    assert np.array_equal(data_container.data_inputs, np.array(list(range(0, 5))))
+    assert np.array_equal(data_container.expected_outputs, np.array(list(range(5, 10))))


### PR DESCRIPTION
Fix bug pointed out here : https://stackoverflow.com/questions/63171160/how-to-correctly-implement-a-neuraxle-pipeline-step-that-filters-data-inputs/63321165#63321165

InputAndOutputTransformerWrapper, and InputAndOutputTransformerMixin should hash data container before validating the length of the current ids, and data inputs. 
Added _DidProcessInputOutputHandlerMixin to do just that. 

Usage example : 

```
    step = InputAndOutputTransformerWrapper(WindowTimeSeriesForOutputTransformerWrapper()) \
        .set_hashers([HashlibMd5ValueHasher()])
    step = StepThatInheritsFromInputAndOutputTransformerMixin().set_hashers([HashlibMd5ValueHasher()])
```
