### PR TITLE
Add MiniBatchSequentialPipeline params for incomplete Batch

### DIFF
--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -142,24 +142,40 @@ class DataContainer:
             m.update(str.encode(str(current_id)))
         return m.hexdigest()
 
-    def convolved_1d(self, stride, kernel_size) -> Iterable['DataContainer']:
+    def convolved_1d(self, stride, kernel_size, include_incomplete_pass: bool = True, default_value: Any = None) -> Iterable['DataContainer']:
         """
         Returns an iterator that iterates through batches of the DataContainer.
 
         :param stride: step size for the convolution operation
         :param kernel_size:
-        :return: an iterator of DataContainer
+        :param include_incomplete_pass: suppose you have a kernel_size of 7 and an iterable length of 3. If
+            include_incomplete_pass is set to True, then you'll have 1 item returned in the loop, otherwise, 0 item.
+        :param default_value: default fill value for padding and values outside iteration range.
+        :param include_incomplete_pass:
         :rtype: Iterable[DataContainer]
 
         .. seealso::
             `<https://github.com/guillaume-chevalier/python-conv-lib>`_
         """
-        conv_current_ids = convolved_1d(stride=stride, iterable=self.current_ids, kernel_size=kernel_size,
-                                        include_incomplete_pass=True)
-        conv_data_inputs = convolved_1d(stride=stride, iterable=self.data_inputs, kernel_size=kernel_size,
-                                        include_incomplete_pass=True)
-        conv_expected_outputs = convolved_1d(stride=stride, iterable=self.expected_outputs, kernel_size=kernel_size,
-                                             include_incomplete_pass=True)
+        conv_current_ids = convolved_1d(
+            stride=stride,
+            iterable=self.current_ids,
+            kernel_size=kernel_size,
+            include_incomplete_pass=include_incomplete_pass
+        )
+        conv_data_inputs = convolved_1d(
+            stride=stride,
+            iterable=self.data_inputs,
+            kernel_size=kernel_size,
+            default_value=default_value,
+            include_incomplete_pass=include_incomplete_pass
+        )
+        conv_expected_outputs = convolved_1d(
+            stride=stride,
+            iterable=self.expected_outputs,
+            kernel_size=kernel_size,
+            include_incomplete_pass=include_incomplete_pass
+        )
 
         for current_ids, data_inputs, expected_outputs in zip(conv_current_ids, conv_data_inputs,
                                                               conv_expected_outputs):

--- a/neuraxle/steps/loop.py
+++ b/neuraxle/steps/loop.py
@@ -108,7 +108,7 @@ class ForEachDataInput(ForceHandleOnlyMixin, ResumableStepMixin, MetaStep):
 
         :return: self, transformed_data_container
         """
-        output_data_container: DataContainer = ListDataContainer.empty(original_data_container=data_container)
+        output_data_container: ListDataContainer = ListDataContainer.empty(original_data_container=data_container)
 
         for current_id, di, eo in data_container:
             self.wrapped, output = self.wrapped.handle_fit_transform(

--- a/testing/test_data_container.py
+++ b/testing/test_data_container.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pytest
 
-from neuraxle.data_container import DataContainer, ListDataContainer
+from neuraxle.data_container import DataContainer, ListDataContainer, AbsentValuesNullObject
 
 
 def test_data_container_iter_method_should_iterate_with_none_current_ids():
@@ -68,3 +69,47 @@ def test_list_data_container_concat():
 
     expected_expected_outputs = np.array(list(range(100, 300))).astype(np.int)
     assert np.array_equal(np.array(data_container.expected_outputs).astype(np.int), expected_expected_outputs)
+
+
+@pytest.mark.parametrize('batch_size,include_incomplete_pass,default_value,expected_data_containers', [
+    (3, False, None, [
+        DataContainer(current_ids=[0, 1, 2], data_inputs=[0, 1, 2], expected_outputs=[10, 11, 12]),
+        DataContainer(current_ids=[3, 4, 5], data_inputs=[3, 4, 5], expected_outputs=[13, 14, 15]),
+        DataContainer(current_ids=[6, 7, 8], data_inputs=[6, 7, 8], expected_outputs=[16, 17, 18]),
+    ]),
+    (3, True, 0, [
+        DataContainer(current_ids=[0, 1, 2], data_inputs=[0, 1, 2], expected_outputs=[10, 11, 12]),
+        DataContainer(current_ids=[3, 4, 5], data_inputs=[3, 4, 5], expected_outputs=[13, 14, 15]),
+        DataContainer(current_ids=[6, 7, 8], data_inputs=[6, 7, 8], expected_outputs=[16, 17, 18]),
+        DataContainer(current_ids=[0, 1, 2], data_inputs=[9, 0, 0], expected_outputs=[19, 0, 0])
+    ]),
+    (3, True, AbsentValuesNullObject(), [
+        DataContainer(current_ids=[0, 1, 2], data_inputs=[0, 1, 2], expected_outputs=[10, 11, 12]),
+        DataContainer(current_ids=[3, 4, 5], data_inputs=[3, 4, 5], expected_outputs=[13, 14, 15]),
+        DataContainer(current_ids=[6, 7, 8], data_inputs=[6, 7, 8], expected_outputs=[16, 17, 18]),
+        DataContainer(current_ids=[9], data_inputs=[9], expected_outputs=[19])
+    ])
+])
+def test_convolved(batch_size, include_incomplete_pass, default_value, expected_data_containers):
+    data_container = DataContainer(
+        current_ids=[str(i) for i in range(10)],
+        data_inputs=np.array(list(range(10))),
+        expected_outputs=np.array(list(range(10, 20)))
+    )
+
+    # When
+    data_containers = []
+    for dc in data_container.convolved_1d(
+        stride=batch_size,
+        kernel_size=batch_size,
+        include_incomplete_pass=include_incomplete_pass,
+        default_value=default_value
+    ):
+        data_containers.append(dc)
+
+    # Then
+    assert len(expected_data_containers) == len(data_containers)
+    for expected_data_container, actual_data_container in zip(expected_data_containers, data_containers):
+        np.array_equal(expected_data_container.current_ids, actual_data_container.current_ids)
+        np.array_equal(expected_data_container.data_inputs, actual_data_container.data_inputs)
+        np.array_equal(expected_data_container.expected_outputs, actual_data_container.expected_outputs)


### PR DESCRIPTION
You can also have incomplete batches with default values :


```python

        p = MiniBatchSequentialPipeline([
            MultiplyByN(2),
            MultiplyByN(2)
            Joiner(
                batch_size=30,
                include_incomplete_pass=True,
                default_value=-10
            )
        ])
        # or
        p = MiniBatchSequentialPipeline([
            MultiplyByN(2),
            MultiplyByN(2)
        ], include_incomplete_pass=True, default_value=-10)

        di = np.array(list(range(20)))
        outputs = p.transform(di)

        assert np.array_equal(outputs, np.concatenate((
            di * 4, # multiplied data inputs
            np.array([-10] * 10) * 4)) # multiplied default values
        )
```