### PR TITLE
Auto update trials on changes

### DIFF
--- a/neuraxle/metaopt/auto_ml.py
+++ b/neuraxle/metaopt/auto_ml.py
@@ -37,7 +37,7 @@ from typing import Callable, List, Union, Tuple
 
 import numpy as np
 
-from neuraxle.base import BaseStep, ExecutionContext, ForceHandleOnlyMixin, ForceHandleMixin, _FittableStep
+from neuraxle.base import BaseStep, ExecutionContext, ForceHandleMixin
 from neuraxle.data_container import DataContainer
 from neuraxle.hyperparams.space import HyperparameterSamples, HyperparameterSpace
 from neuraxle.metaopt.callbacks import BaseCallback, CallbackList, ScoringCallback
@@ -327,7 +327,10 @@ class HyperparamsJSONRepository(HyperparamsRepository):
                     continue
 
             if status is None or trial_json['status'] == status.value:
-                trials.append(Trial.from_json(trial_json=trial_json))
+                trials.append(Trial.from_json(
+                    hyperparams_repository=self,
+                    trial_json=trial_json
+                ))
 
         return trials
 

--- a/neuraxle/metaopt/trial.py
+++ b/neuraxle/metaopt/trial.py
@@ -27,11 +27,21 @@ import traceback
 from enum import Enum
 from typing import Dict, List
 
+from neuraxle.metaopt.auto_ml import HyperparamsRepository
+
 from neuraxle.base import BaseStep, ExecutionContext
 from neuraxle.data_container import DataContainer
 from neuraxle.hyperparams.space import HyperparameterSamples
 
 TRIAL_DATETIME_STR_FORMAT = '%m/%d/%Y, %H:%M:%S'
+
+def update_trial(func):
+    def wrapper(*args, **kwargs):
+        self_in_args = args[0]
+        output = func(*args, **kwargs)
+        self_in_args.update()
+        return output
+    return wrapper
 
 
 class Trial:
@@ -53,6 +63,7 @@ class Trial:
             self,
             hyperparams: HyperparameterSamples,
             main_metric_name: str,
+            hyperparams_repository: HyperparamsRepository,
             status: 'TRIAL_STATUS' = None,
             pipeline: BaseStep = None,
             validation_splits: List['TrialSplit'] = None,
@@ -67,7 +78,8 @@ class Trial:
         if validation_splits is None:
             validation_splits = []
 
-        self.main_metric_name = main_metric_name
+        self.hyperparams_repository: HyperparamsRepository = hyperparams_repository
+        self.main_metric_name: str = main_metric_name
         self.status: TRIAL_STATUS = status
         self.hyperparams: HyperparameterSamples = hyperparams
         self.pipeline: BaseStep = pipeline
@@ -77,6 +89,15 @@ class Trial:
         self.error: str = error
         self.start_time: datetime.datetime = start_time
         self.end_time: datetime.datetime = end_time
+
+    def update(self) -> 'Trial':
+        """
+        Update trial with the hyperparams repository.
+
+        :return:
+        """
+        self.hyperparams_repository.save_trial(self)
+        return self
 
     def new_validation_split(self, pipeline: BaseStep, delete_pipeline_on_completion: bool = True) -> 'TrialSplit':
         """
@@ -89,6 +110,7 @@ class Trial:
         :return: one trial split
         """
         trial_split: TrialSplit = TrialSplit(
+            trial=self,
             split_number=len(self.validation_splits),
             main_metric_name=self.main_metric_name,
             pipeline=pipeline,
@@ -96,6 +118,7 @@ class Trial:
         )
         self.validation_splits.append(trial_split)
 
+        self.update()
         return trial_split
 
     def save_model(self):
@@ -157,6 +180,7 @@ class Trial:
         :return: self
         """
         self.status = TRIAL_STATUS.SUCCESS
+        self.update()
 
         return self
 
@@ -174,6 +198,8 @@ class Trial:
         else:
             self.status = TRIAL_STATUS.FAILED
 
+        self.update()
+
     def set_failed(self, error: Exception) -> 'Trial':
         """
         Set failed trial with exception.
@@ -184,6 +210,8 @@ class Trial:
         self.status = TRIAL_STATUS.FAILED
         self.error = str(error)
         self.error_traceback = traceback.format_exc()
+
+        self.update()
 
         return self
 
@@ -219,20 +247,26 @@ class Trial:
         }
 
     @staticmethod
-    def from_json(trial_json: Dict) -> 'Trial':
-        return Trial(
+    def from_json(hyperparams_repository: HyperparamsRepository, trial_json: Dict) -> 'Trial':
+        trial: Trial = Trial(
             main_metric_name=trial_json['main_metric_name'],
             status=TRIAL_STATUS(trial_json['status']),
             hyperparams=HyperparameterSamples(trial_json['hyperparams']),
-            validation_splits=[
-                TrialSplit.from_json(validation_split_json)
-                for validation_split_json in trial_json['validation_splits']
-            ],
+            hyperparams_repository=hyperparams_repository,
             error=trial_json['error'],
             error_traceback=trial_json['error_traceback'],
             start_time=datetime.datetime.strptime(trial_json['start_time'], TRIAL_DATETIME_STR_FORMAT),
             end_time=datetime.datetime.strptime(trial_json['start_time'], TRIAL_DATETIME_STR_FORMAT)
         )
+
+        trial.validation_splits = [
+            TrialSplit.from_json(
+                trial=trial,
+                trial_split_json=validation_split_json
+            ) for validation_split_json in trial_json['validation_splits']
+        ]
+
+        return trial
 
     def __enter__(self):
         """
@@ -240,6 +274,7 @@ class Trial:
         """
         self.start_time = datetime.datetime.now()
         self.status = TRIAL_STATUS.STARTED
+        self.update()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -255,7 +290,10 @@ class Trial:
         del self.pipeline
         if exc_type is not None:
             self.set_failed(exc_val)
+            self.update()
             raise exc_val
+
+        self.update()
         return self
 
 
@@ -273,7 +311,8 @@ class TrialSplit:
 
     def __init__(
             self,
-            split_number,
+            trial: Trial,
+            split_number: int,
             main_metric_name: str,
             status: 'TRIAL_STATUS' = None,
             error: Exception = None,
@@ -287,6 +326,7 @@ class TrialSplit:
         if status is None:
             status = TRIAL_STATUS.PLANNED
 
+        self.trial: Trial = trial
         self.split_number: int = split_number
         self.status: TRIAL_STATUS = status
         self.error: Exception = error
@@ -299,6 +339,15 @@ class TrialSplit:
         self.pipeline: BaseStep = pipeline
         self.main_metric_name: str = main_metric_name
         self.delete_pipeline_on_completion = delete_pipeline_on_completion
+
+    def update(self) -> 'TrialSplit':
+        """
+        Update parent trial.
+
+        :return: self
+        """
+        self.trial.update()
+        return self
 
     def fit_trial_split(self, train_data_container: DataContainer, context: ExecutionContext) -> 'TrialSplit':
         """
@@ -349,6 +398,7 @@ class TrialSplit:
             }
 
         self.metrics_results[name]['train_values'].append(score)
+        self.update()
 
     def add_metric_results_validation(self, name: str, score: float, higher_score_is_better: bool):
         """
@@ -367,6 +417,7 @@ class TrialSplit:
             }
 
         self.metrics_results[name]['validation_values'].append(score)
+        self.update()
 
     def get_validation_scores(self):
         """
@@ -445,22 +496,24 @@ class TrialSplit:
         }
 
     @staticmethod
-    def from_json(trial_json: Dict) -> 'TrialSplit':
+    def from_json(trial: 'Trial', trial_split_json: Dict) -> 'TrialSplit':
         """
         Create a trial split object from json.
 
-        :param trial_json: trial json
+        :param trial: parent trial
+        :param trial_split_json: trial json
         :return:
         """
         return TrialSplit(
-            status=TRIAL_STATUS(trial_json['status']),
-            error=trial_json['error'],
-            error_traceback=trial_json['error_traceback'],
-            metrics_results=trial_json['metric_results'],
-            start_time=datetime.datetime.strptime(trial_json['start_time'], TRIAL_DATETIME_STR_FORMAT),
-            end_time=datetime.datetime.strptime(trial_json['end_time'], TRIAL_DATETIME_STR_FORMAT),
-            split_number=trial_json['split_number'],
-            main_metric_name=trial_json['main_metric_name']
+            trial=trial,
+            status=TRIAL_STATUS(trial_split_json['status']),
+            error=trial_split_json['error'],
+            error_traceback=trial_split_json['error_traceback'],
+            metrics_results=trial_split_json['metric_results'],
+            start_time=datetime.datetime.strptime(trial_split_json['start_time'], TRIAL_DATETIME_STR_FORMAT),
+            end_time=datetime.datetime.strptime(trial_split_json['end_time'], TRIAL_DATETIME_STR_FORMAT),
+            split_number=trial_split_json['split_number'],
+            main_metric_name=trial_split_json['main_metric_name']
         )
 
     def set_success(self) -> 'TrialSplit':
@@ -470,6 +523,7 @@ class TrialSplit:
         :return: self
         """
         self.status = TRIAL_STATUS.SUCCESS
+        self.update()
         return self
 
     def is_success(self):
@@ -488,6 +542,7 @@ class TrialSplit:
         self.status = TRIAL_STATUS.FAILED
         self.error = str(error)
         self.error_traceback = traceback.format_exc()
+        self.update()
         return self
 
     def __enter__(self):
@@ -496,6 +551,7 @@ class TrialSplit:
         """
         self.start_time = datetime.datetime.now()
         self.status = TRIAL_STATUS.STARTED
+        self.update()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -514,6 +570,7 @@ class TrialSplit:
             self.set_failed(exc_val)
             raise exc_val
 
+        self.update()
         return self
 
     def __str__(self):

--- a/testing/metaopt/test_trial.py
+++ b/testing/metaopt/test_trial.py
@@ -1,5 +1,7 @@
 import datetime
 
+from neuraxle.metaopt.auto_ml import InMemoryHyperparamsRepository
+
 from neuraxle.base import Identity
 from neuraxle.hyperparams.space import HyperparameterSamples
 from neuraxle.metaopt.trial import Trial, TRIAL_STATUS, TRIAL_DATETIME_STR_FORMAT, Trials
@@ -19,7 +21,12 @@ MAIN_METRIC_NAME = 'mse'
 
 def test_trial_should_create_new_split():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name=MAIN_METRIC_NAME)
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(
+        save_trial_function=repo.save_trial,
+        hyperparams=hp,
+        main_metric_name=MAIN_METRIC_NAME
+    )
 
     with trial.new_validation_split(Identity()) as trial_split:
         trial_split.set_success()
@@ -32,7 +39,8 @@ def test_trial_should_create_new_split():
 
 def test_trial_split_is_new_best_score_should_return_true_with_one_score():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name=MAIN_METRIC_NAME)
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(save_trial_function=repo.save_trial, hyperparams=hp, main_metric_name=MAIN_METRIC_NAME)
 
     with trial.new_validation_split(Identity()) as trial_split:
         trial_split.add_metric_results_train(name=MAIN_METRIC_NAME, score=0.5, higher_score_is_better=False)
@@ -44,7 +52,8 @@ def test_trial_split_is_new_best_score_should_return_true_with_one_score():
 
 def test_trial_split_is_new_best_score_should_return_false_with_not_a_new_best_score():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name=MAIN_METRIC_NAME)
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(save_trial_function=repo.save_trial, hyperparams=hp, main_metric_name=MAIN_METRIC_NAME)
 
     with trial.new_validation_split(Identity()) as trial_split:
         trial_split.add_metric_results_train(name=MAIN_METRIC_NAME, score=0.5, higher_score_is_better=False)
@@ -60,7 +69,8 @@ def test_trial_split_is_new_best_score_should_return_false_with_not_a_new_best_s
 
 def test_trial_split_is_new_best_score_should_return_true_with_a_new_best_score_after_multiple_scores():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name=MAIN_METRIC_NAME)
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(save_trial_function=repo.save_trial, hyperparams=hp, main_metric_name=MAIN_METRIC_NAME)
 
     with trial.new_validation_split(Identity()) as trial_split:
         trial_split.add_metric_results_train(name=MAIN_METRIC_NAME, score=0.5, higher_score_is_better=False)
@@ -80,7 +90,12 @@ def test_trial_split_is_new_best_score_should_return_true_with_a_new_best_score_
 
 def test_success_trial_split_to_json():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name=MAIN_METRIC_NAME)
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(
+        save_trial_function=repo.save_trial,
+        hyperparams=hp,
+        main_metric_name=MAIN_METRIC_NAME
+    )
 
     with trial:
         trial_split = given_success_trial_validation_split(trial)
@@ -105,7 +120,12 @@ def then_success_trial_split_json_is_valid(trial_json):
 
 def test_success_trial_to_json():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name='mse')
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(
+        save_trial_function=repo.save_trial,
+        hyperparams=hp,
+        main_metric_name='mse'
+    )
 
     with trial:
         given_success_trial_validation_split(trial)
@@ -127,7 +147,8 @@ def test_success_trial_to_json():
 
 def test_success_trial_get_validation_score():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name='mse')
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(save_trial_function=repo.save_trial, hyperparams=hp, main_metric_name='mse')
 
     with trial:
         given_success_trial_validation_split(trial, best_score=0.3)
@@ -139,7 +160,8 @@ def test_success_trial_get_validation_score():
 
 def test_success_trial_multiple_splits_should_average_the_scores():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name='mse')
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(save_trial_function=repo.save_trial, hyperparams=hp, main_metric_name='mse')
 
     with trial:
         given_success_trial_validation_split(trial, best_score=0.3)
@@ -152,7 +174,8 @@ def test_success_trial_multiple_splits_should_average_the_scores():
 
 def test_trial_with_failed_split_should_only_average_successful_splits():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name='mse')
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(save_trial_function=repo.save_trial, hyperparams=hp, main_metric_name='mse')
 
     with trial:
         given_success_trial_validation_split(trial, best_score=0.3)
@@ -186,7 +209,8 @@ def given_success_trial_validation_split(trial, best_score=0.4):
 
 def test_failure_trial_split_to_json():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name='mse')
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(save_trial_function=repo.save_trial, hyperparams=hp, main_metric_name='mse')
     with trial:
         trial_split = given_failed_trial_split(trial)
 
@@ -211,7 +235,8 @@ def then_failed_validation_split_json_is_valid(trial_json, trial_split):
 
 def test_failure_trial_to_json():
     hp = HyperparameterSamples({'a': 2})
-    trial = Trial(hyperparams=hp, main_metric_name='mse')
+    repo = InMemoryHyperparamsRepository()
+    trial = Trial(save_trial_function=repo.save_trial, hyperparams=hp, main_metric_name='mse')
 
     with trial:
         trial_split = given_failed_trial_split(trial)
@@ -252,13 +277,14 @@ def given_failed_trial_split(trial):
 
 def test_trials_get_best_hyperparams_should_return_hyperparams_of_best_trial():
     # Given
+    repo = InMemoryHyperparamsRepository()
     hp_trial_1 = HyperparameterSamples({'a': 2})
-    trial_1 = Trial(hyperparams=hp_trial_1, main_metric_name=MAIN_METRIC_NAME)
+    trial_1 = Trial(save_trial_function=repo.save_trial, hyperparams=hp_trial_1, main_metric_name=MAIN_METRIC_NAME)
     with trial_1:
         given_success_trial_validation_split(trial_1, best_score=0.2)
 
     hp_trial_2 = HyperparameterSamples({'b': 3})
-    trial_2 = Trial(hyperparams=hp_trial_2, main_metric_name=MAIN_METRIC_NAME)
+    trial_2 = Trial(save_trial_function=repo.save_trial, hyperparams=hp_trial_2, main_metric_name=MAIN_METRIC_NAME)
     with trial_2:
         given_success_trial_validation_split(trial_2, best_score=0.1)
 


### PR DESCRIPTION
# What it is

My pull request does: update trial inside hyperparams repository after any changes


# How it works

I coded it this way: 
- pass the save_trial_function to Trial (a callback instead of the repo itself to avoid circular references)
- pass the reference to the parent Trial to TrialSplit
- added a reference to the hyperparams repository inside Trainer. this way we can save trials even if we are not in an automl loop. (the default repo is in memory; it is acting like a null object)

