### PR TITLE
Fix: _WithContextSaver load function

### DIFF
--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -3776,7 +3776,7 @@ class _WithContextStepSaver(BaseSaver):
         :return: loaded step with context
         """
         step.context = context
-        step.apply('_assert_has_services', context=context)
+        print("Warning! the loading of a StepWithContext instance overrides the context attribute with the one provided at loading.")
         return step
 
     def save_step(self, step: 'StepWithContext', context: ExecutionContext) -> 'StepWithContext':

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -3776,7 +3776,7 @@ class _WithContextStepSaver(BaseSaver):
         :return: loaded step with context
         """
         step.context = context
-        print("Warning! the loading of a StepWithContext instance overrides the context attribute with the one provided at loading.")
+        warnings.warn("Warning! the loading of a StepWithContext instance overrides the context attribute with the one provided at loading.")
         return step
 
     def save_step(self, step: 'StepWithContext', context: ExecutionContext) -> 'StepWithContext':

--- a/testing/test_service_assertions.py
+++ b/testing/test_service_assertions.py
@@ -58,17 +58,21 @@ class RegisterServiceDynamically(ForceHandleMixin, Identity):
         return data_container
 
 
-def test_step_with_context_should_only_save_wrapped_step(tmpdir):
+def test_step_with_context_saver(tmpdir):
     context = ExecutionContext(root=tmpdir)
     service = SomeService()
+    pipeline_name = 'testname'
     context.set_service_locator({SomeBaseService: service})
     p = Pipeline([
         SomeStep().assert_has_services(SomeBaseService)
     ]).with_context(context=context)
-
+    p.set_name(pipeline_name)
     p.save(context, full_dump=True)
 
-    p: Pipeline = ExecutionContext(root=tmpdir).load(os.path.join('StepWithContext', 'Pipeline'))
+    p: StepWithContext = ExecutionContext(root=tmpdir).load(pipeline_name)
+    assert isinstance(p, StepWithContext)
+
+    p: Pipeline = ExecutionContext(root=tmpdir).load(os.path.join(pipeline_name, 'Pipeline'))
     assert isinstance(p, Pipeline)
 
 


### PR DESCRIPTION
This fix solves the problem mentionned in #445.

It seems like there was a bug in the _WithContextSaver load function. The bug originated from an apply call to "_assert_has_service". While it is understandable that one may want to check the presence of service at loading, it is not possible to do so before the loading of the rest of the pipeline (_WithContextSaver is executed before MetaStepJoblibsaver).

The current assertion interface checks services before the execution of the pipeline, and before the execution of a given step. I believe it is sufficient and performing service assertion at loading is a bit over-zealous and too restrictive.

