### PR TITLE
Fix dependencies (new matplotlib release not compatible with python 3.6)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ setuptools
 pytest==4.3.1
 pytest-cov==2.6.1
 numpy>=1.16.2
-matplotlib=3.3.4
+matplotlib==3.3.4
 scikit-learn>=0.20.3
 scipy>=1.4.1
 joblib>=0.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ setuptools
 pytest==4.3.1
 pytest-cov==2.6.1
 numpy>=1.16.2
+matplotlib=3.3.4
 pandas
 scikit-learn>=0.20.3
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy>=1.16.2
 matplotlib==3.3.4
 scikit-learn>=0.20.3
 scipy>=1.4.1
+pandas
 joblib>=0.13.2
 flask>=1.1.1
 flask-restful>=0.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ pytest==4.3.1
 pytest-cov==2.6.1
 numpy>=1.16.2
 matplotlib=3.3.4
-pandas
 scikit-learn>=0.20.3
 scipy>=1.4.1
 joblib>=0.13.2

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         'numpy',
         'scipy>=1.4.1',
         'scikit-learn>=0.20.3',
-        'matplotlib=3.3.4',
+        'matplotlib==3.3.4',
         'joblib>=0.13.2',
         'Flask>=1.1.1',
         'Flask-RESTful>=0.3.7',

--- a/setup.py
+++ b/setup.py
@@ -94,11 +94,10 @@ setup(
         'numpy',
         'scipy>=1.4.1',
         'scikit-learn>=0.20.3',
-        'matplotlib',
+        'matplotlib=3.3.4',
         'joblib>=0.13.2',
         'Flask>=1.1.1',
         'Flask-RESTful>=0.3.7',
-        'conv==0.2'
     ],
     tests_require=[
         "pytest",


### PR DESCRIPTION
# What it is

My pull request does: 

The new matplotlib release (3.4) is not compatible with python 3.6. So I set the matplotlib version in setup.py. I decided to use the occasion to go through the list of requirements (both in requirements.txt and setup.py) and remove any unused dependencies.
