### PR TITLE
Added feature to compress hps

### DIFF
--- a/neuraxle/hyperparams/space.py
+++ b/neuraxle/hyperparams/space.py
@@ -64,7 +64,7 @@ ready to be sent to an instance of the pipeline to try and score it, for example
 from collections import OrderedDict, ItemsView
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List
 
 from scipy.stats import rv_continuous, rv_discrete
 from scipy.stats._distn_infrastructure import rv_generic
@@ -229,7 +229,7 @@ class HyperparameterSamples(RecursiveDict):
         super().__init__(*args, separator=separator, **kwds)
 
     def compress(self) -> 'CompressedHyperparameterSamples':
-        """Compresses the HyperparameterSamples representation """
+        """Compresses the HyperparameterSamples representation"""
 
         return CompressedHyperparameterSamples(self)
 
@@ -237,6 +237,7 @@ class HyperparameterSamples(RecursiveDict):
 @dataclass
 class CompressedHyperparameter:
     """CompressedHyperParameter"""
+
     step_name: str
     hyperparams: dict
     ancestor_steps: list
@@ -248,12 +249,14 @@ class CompressedHyperparameterSamples:
     """
 
     def __init__(self, hps: HyperparameterSamples):
+        """Takes in `HyperparameterSamples` object and generates a compressed _seq"""
         if not hps or not isinstance(hps, HyperparameterSamples):
             raise ValueError("pass a valid `HyperparameterSamples` object")
         self.separator: str = hps.separator
         self._seq: List[dict] = self._convert(hps)
 
     def __str__(self) -> str:
+        """Prints the `CompressedHyperparameterSamples._seq`."""
         return f"{self._seq}"
 
     def _group_hps_by_step(self, flat_steps_hps: ItemsView) -> 'OrderedDict[str, dict]':
@@ -275,7 +278,7 @@ class CompressedHyperparameterSamples:
         return grouped_hyper_params
 
     def _convert_to_compressed_format(self, group_by_step: 'OrderedDict[str, dict]') -> 'List[dict]':
-        """Converts grouped hyper params to Compressed format"""
+        """Converts grouped hyper params to Compressed format."""
         compressed = []
         for steps in group_by_step:
             *prev_steps, current_step = steps.split(self.separator)

--- a/neuraxle/hyperparams/space.py
+++ b/neuraxle/hyperparams/space.py
@@ -63,6 +63,7 @@ ready to be sent to an instance of the pipeline to try and score it, for example
 """
 from collections import OrderedDict
 from copy import deepcopy
+from dataclasses import dataclass
 
 from scipy.stats import rv_continuous, rv_discrete
 from scipy.stats._distn_infrastructure import rv_generic
@@ -210,8 +211,8 @@ class RecursiveDict(OrderedDict):
         return type(self)(
             separator=separator,
             **{key: value if not isinstance(value, RecursiveDict) \
-                    else value.with_separator(separator) for key, value in self.items()
-            })
+                else value.with_separator(separator) for key, value in self.items()
+               })
 
 
 class HyperparameterSamples(RecursiveDict):
@@ -225,6 +226,61 @@ class HyperparameterSamples(RecursiveDict):
 
     def __init__(self, *args, separator=None, **kwds):
         super().__init__(*args, separator=separator, **kwds)
+
+    def compress(self, trim_parents=False):
+        """Compresses the HyperparameterSamples representation """
+        grouped_result = self._group_hps_by_step(flat_steps_hps=self.items())
+        return self._convert_to_compressed_format(group_by_step=grouped_result, trim_parents=trim_parents)
+
+    def _group_hps_by_step(self, flat_steps_hps: list) -> dict:
+        """
+        Groups hyperparams
+        :param flat_steps_hps: Flat list of steps and hyper parameter
+        :return: OrderedDict containning grouped hyperparams as values and keys as pipeline stages & steps
+
+        >>>hyper_params = [('AddFeatures__PCA__copy', True), ('AddFeatures__PCA__iterated_power', 'auto')]
+        >>>self._group_hps_by_step(hyper_params = hyper_params)
+        ...OrderedDict([('AddFeatures__PCA', OrderedDict([('copy', True), ('iterated_power', 'auto')]))])
+        """
+        grouped_hyper_params = OrderedDict()
+        for steps_and_hps, hyper_param_val in flat_steps_hps:
+            *steps, hyper_param_key = steps_and_hps.split(self.separator)
+            grouped_hyper_params.setdefault(f"{self.separator}".join(steps), OrderedDict()).update({
+                hyper_param_key: hyper_param_val})
+
+        return grouped_hyper_params
+
+    def _convert_to_compressed_format(self, group_by_step, trim_parents=False):
+        """Converts grouped hyper params to Compressed format"""
+        compressed = []
+        for steps in group_by_step:
+            *prev_steps, current_step = steps.split(self.separator)
+            hps = group_by_step[steps]
+
+            compressed.append(CompressedHyperParameter(step_name=current_step, hyper_parameters=hps,
+                                                       ancestor_steps=prev_steps if not trim_parents else None).__dict__)
+        return CompressedHyperparameterSamples(compressed)
+
+
+@dataclass
+class CompressedHyperParameter:
+    """CompressedHyperParameter"""
+    step_name: str
+    hyper_parameters: dict
+    ancestor_steps: list
+
+
+class CompressedHyperparameterSamples(HyperparameterSamples):
+    """
+    Short-hand representation of `HyperparameterSamples`
+    """
+
+    def __init__(self, seq):
+        super(CompressedHyperparameterSamples, self).__init__()
+        self._seq = seq
+
+    def __str__(self):
+        return f"{self._seq}"
 
 
 class HyperparameterSpace(RecursiveDict):


### PR DESCRIPTION
<!-- Thank you for opening a pull request!

Please add example code and a good description for us to properly review your code.

If this is your first contribution, you'll need to sign the Contributor License Agreement to allow us to use your changes: 
https://docs.google.com/forms/d/e/1FAIpQLSfDP3eCQoV0tMq296OfbOpNn-QkHwfJQLkS0MVjSHiZQXPw2Q/viewform

Please fill in the informations below if this is pertinent for your Pull Request. -->


# What it is

My pull request does: 
This change will try to compress the flat list of hyperparams, into a more structured representation.
Please refer the following [PR](https://github.com/Neuraxio/Neuraxle/issues/486) for more information.
I haven't added any tests for now, i wanted to make sure this implementation is reviewed.

# How it works

I coded it this way: 
Current implementation will try to read the `all_hps = pipeline.get_hyperparams()` output and try to compress this particular output into more structured and readable format.

# Example usage

Here is how you can use this new code as a end user: 


```python 
Note: 
Please make dimensions and types clear to the reader.
E.g.: in the event fictious data is processed in this code example.

>>>all_hps = pipeline.get_hyperparams()\
>>>all_hps_shortened = all_hps.compress()
>>>print(type(all_hps_shortened))
...<class 'neuraxle.hyperparams.space.CompressedHyperparameterSamples'>
>>>pprint(all_hps_shortened)
...[
    {

        "step_name": "step1",
        "hyper_parameters": OrderedDict([('copy', True), ('iterated_power', 'auto')]),
        "ancestor_steps": ["root"]
    },
    {

        "step_name": "step1",
        "hyper_parameters":OrderedDict([('copy', True), ('iterated_power', 'auto')]),
        "ancestor_steps": ["root"]
    }

]

```


<!-- Checklist before merging PR: 

[ ] The above description of the pull request was used to document the new code. 
[ ] Class names and argument / API variables are very clear: there is no possible ambiguity. 
[ ] Argument's dimensions and types are specified for new steps (important). 
[ ] Classes are documented: their behavior is explained beyond just the title of the class. 
[ ] If a numpy array is used, it is important to remember that these arrays are a special type that must be documented accordingly, and that numpy array should not be abused. This is because Neuraxle is a library that is not only limited to transforming numpy arrays. To this effect, numpy steps should probably be located in the existing numpy python files as much as possible. 
[ ] Code coverage is above 90% for the added code. 

-->
