### PR TITLE
General improvements and bugfixes

### DIFF
--- a/examples/auto_ml/plot_automl_loop_clean_kata.py
+++ b/examples/auto_ml/plot_automl_loop_clean_kata.py
@@ -116,7 +116,7 @@ def main(tmpdir: str):
     auto_ml = AutoML(
         pipeline=pipeline,
         hyperparams_optimizer=RandomSearchSampler(),
-        validation_splitter=ValidationSplitter(validation_size=0.20),
+        validation_splitter=ValidationSplitter(validation_size=0.20).set_to_force_expected_outputs_for_scoring(),
         scoring_callback=ScoringCallback(accuracy_score, higher_score_is_better=True),
         n_trials=7,
         epochs=1,

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -2689,7 +2689,8 @@ class _HasHyperparams(MixinForBaseService):
         output = ''
         if verbose:
             hps: HyperparameterSamples = self._get_hyperparams()
-            if len(hps) > 0:
+            if not hps.is_empty():
+                # hps = hps.to_flat_dict(use_wildcards=not verbose)
                 output += ", hyperparams=" + pprint.pformat(hps)
         return output
 

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -1999,7 +1999,7 @@ class _FittableStep(MixinForBaseService):
         :param context: execution context
         :return: (fitted self, data container)
         """
-        return self.fit(data_container.di, data_container.eo)
+        return self.fit(data_container.data_inputs, data_container.expected_outputs)
 
     def _did_fit(self, data_container: TrainDACT, context: CX) -> TrainDACT:
         """
@@ -2072,7 +2072,7 @@ class _FittableStep(MixinForBaseService):
         :param context: execution context
         :return: (fitted self, data container)
         """
-        new_self, out = self.fit_transform(data_container.di, data_container.eo)
+        new_self, out = self.fit_transform(data_container.data_inputs, data_container.expected_outputs)
         data_container.set_data_inputs(out)
 
         return new_self, data_container
@@ -4273,7 +4273,7 @@ class DidProcessAssertionMixin(AssertionMixin):
 
 class AssertExpectedOutputIsNoneMixin(WillProcessAssertionMixin):
     def _assert_at_lifecycle(self, data_container: DACT, context: CX):
-        eo_empty = (data_container.expected_outputs is None) or all(v is None for v in data_container.eo)
+        eo_empty = (data_container.expected_outputs is None) or all(v is None for v in data_container.expected_outputs)
         self._assert(
             eo_empty,
             f"Expected datacontainer.expected_outputs to be a `None` or a list of `None`. Received {data_container.expected_outputs}.",
@@ -4283,7 +4283,7 @@ class AssertExpectedOutputIsNoneMixin(WillProcessAssertionMixin):
 
 class AssertExpectedOutputIsNotNoneMixin(WillProcessAssertionMixin):
     def _assert_at_lifecycle(self, data_container: DACT, context: CX):
-        eo_empty = (data_container.expected_outputs is None) or all(v is None for v in data_container.eo)
+        eo_empty = (data_container.expected_outputs is None) or all(v is None for v in data_container.expected_outputs)
         self._assert(
             not eo_empty,
             f"Expected datacontainer.expected_outputs to not be a `None` nor a list of `None`. Received {data_container.expected_outputs}.",

--- a/neuraxle/base.py
+++ b/neuraxle/base.py
@@ -1022,6 +1022,37 @@ class _TruncableMixin(MixinForBaseService):
         return output
 
 
+class _TruncableServiceWithBodyMixin(MixinForBaseService):
+    """
+    This is a mixin to enable the .joiner and .body methods to be
+    used on a truncable step that has a joiner at its end.
+    """
+
+    def __init__(self):
+        MixinForBaseService.__init__(self)
+
+    @property
+    def joiner(self) -> BaseService:
+        """
+        returns `self[-1]`
+        """
+        return self[-1]
+
+    @property
+    def body(self) -> List[BaseService]:
+        """
+        returns `list(self.values())[:-1]`, that is all the steps except the last joiner.
+        """
+        return list(self.values())[:-1]
+
+    @property
+    def named_body(self) -> List[BaseService]:
+        """
+        returns `list(self.values())[:-1]`, that is all the steps except the last joiner.
+        """
+        return self[:-1]
+
+
 class TruncableServiceMixin(_TruncableMixin, _HasChildrenMixin):
 
     def __init__(self, services: Dict[ServiceName, 'BaseServiceT']):
@@ -2229,6 +2260,9 @@ class _CustomHandlerMethods(MixinForBaseService):
         :class:`~neuraxle.pipeline.MiniBatchSequentialPipeline`,
         :class:`~neuraxle.distributed.streaming.BaseQueuedPipeline`
     """
+
+    def __init__(self):
+        MixinForBaseService.__init__(self)
 
     def handle_fit(self, data_container: TrainDACT, context: CX) -> 'BaseStep':
         """

--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -501,7 +501,7 @@ class DataContainer(Generic[IDT, DIT, EOT]):
         :rtype: Iterator[Tuple]
         """
         if self.data_inputs is None:
-            return iter()
+            return iter(())
 
         _ids: Optional[List[DACTData]] = self.ids
         _di: Optional[List[DACTData]] = self.di

--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -363,9 +363,9 @@ class DataContainer(Generic[IDT, DIT, EOT]):
         """
         for i in range(0, len(self.data_inputs), batch_size):
             data_container: DACT[IDT, DIT, EOT] = DACT(
-                ids=self._ids[i:i + batch_size] if self._ids is not None else None,
-                data_inputs=self.data_inputs[i:i + batch_size] if self.data_inputs is not None else None,
-                expected_outputs=self.expected_outputs[i:i + batch_size] if self.expected_outputs is not None else None
+                ids=self.ids[i:i + batch_size] if self._ids is not None else None,
+                data_inputs=self.di[i:i + batch_size] if self.data_inputs is not None else None,
+                expected_outputs=self.eo[i:i + batch_size] if self.expected_outputs is not None else None
             )
 
             incomplete_batch = len(data_container.data_inputs) < batch_size

--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -500,12 +500,15 @@ class DataContainer(Generic[IDT, DIT, EOT]):
         :return: iterator of tuples containing ids, data_inputs, and expected outputs
         :rtype: Iterator[Tuple]
         """
+        if self.data_inputs is None:
+            return iter()
+
         _ids: Optional[List[DACTData]] = self.ids
         _di: Optional[List[DACTData]] = self.di
         _eo: Optional[List[DACTData]] = self.eo
-        if None in (_ids, _di, _eo):
-            # return empty iterator if one of the three is None
+        if _ids is None or _di is None or _eo is None:
             return iter(())
+
         return zip(_ids, _di, _eo)
 
     def __repr__(self):

--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -500,7 +500,13 @@ class DataContainer(Generic[IDT, DIT, EOT]):
         :return: iterator of tuples containing ids, data_inputs, and expected outputs
         :rtype: Iterator[Tuple]
         """
-        return zip(self.ids, self.di, self.eo)
+        _ids: Optional[List[DACTData]] = self.ids
+        _di: Optional[List[DACTData]] = self.di
+        _eo: Optional[List[DACTData]] = self.eo
+        if None in (_ids, _di, _eo):
+            # return empty iterator if one of the three is None
+            return iter(())
+        return zip(_ids, _di, _eo)
 
     def __repr__(self):
         return str(self)

--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -363,9 +363,9 @@ class DataContainer(Generic[IDT, DIT, EOT]):
         """
         for i in range(0, len(self.data_inputs), batch_size):
             data_container: DACT[IDT, DIT, EOT] = DACT(
-                ids=self.ids[i:i + batch_size] if self.ids is not None else None,
-                data_inputs=self.di[i:i + batch_size] if self.data_inputs is not None else None,
-                expected_outputs=self.eo[i:i + batch_size] if self.expected_outputs is not None else None
+                ids=self._ids[i:i + batch_size] if self._ids is not None else None,
+                data_inputs=self.data_inputs[i:i + batch_size] if self.data_inputs is not None else None,
+                expected_outputs=self.expected_outputs[i:i + batch_size] if self.expected_outputs is not None else None
             )
 
             incomplete_batch = len(data_container.data_inputs) < batch_size

--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -506,20 +506,23 @@ class DataContainer(Generic[IDT, DIT, EOT]):
         return str(self)
 
     def __str__(self):
-        di_rep = self._str_data(self.di)
-        eo_rep = self._str_data(self.eo)
+        di_rep = self._str_data(self.data_inputs)
+        eo_rep = self._str_data(self.expected_outputs)
         return (
             f"{self.__class__.__name__}("
-            f"ids={repr(list(self.ids))}, "
+            f"ids={repr(list(self._ids))}, "
             f"di={di_rep}, "
             f"eo={eo_rep})"
         )
 
     def _str_data(self, _idata: DACTData) -> str:
+        if _idata is None:
+            return str(None)
         if hasattr(_idata, '__len__'):
             if len(_idata) > 10:
-                _len_rep = ("<of len=" + str(len(self.di)) + ">") if hasattr(self.di, "__len__") else ""
-                _rep = f"{type(self.di)}{_len_rep}"
+                _shortrepr = repr(_idata[:10]) + "+..."
+                _len_rep = (f"<{_shortrepr} of len={len(self.di)}>") if hasattr(self.di, "__len__") else "..?"
+                _rep = f"{type(self.di)}[{_len_rep}]"
             else:
                 _rep = repr(_idata)
         return _rep

--- a/neuraxle/data_container.py
+++ b/neuraxle/data_container.py
@@ -361,9 +361,9 @@ class DataContainer(Generic[IDT, DIT, EOT]):
         """
         for i in range(0, len(self.data_inputs), batch_size):
             data_container: DACT[IDT, DIT, EOT] = DACT(
-                ids=self.ids[i:i + batch_size],
-                data_inputs=self.di[i:i + batch_size],
-                expected_outputs=self.eo[i:i + batch_size]
+                ids=self.ids[i:i + batch_size] if self.ids is not None else None,
+                data_inputs=self.di[i:i + batch_size] if self.data_inputs is not None else None,
+                expected_outputs=self.eo[i:i + batch_size] if self.expected_outputs is not None else None
             )
 
             incomplete_batch = len(data_container.data_inputs) < batch_size
@@ -770,21 +770,23 @@ def _pad_incomplete_batch(
             batch_size=batch_size
         ) if pad_ids else data_container.ids,
         data_inputs=_pad_data(
-            data_container.di,
+            data_container.data_inputs,
             default_value=default_value_data_inputs,
             batch_size=batch_size
-        ) if pad_di else data_container.di,
+        ) if pad_di else data_container.data_inputs,
         expected_outputs=_pad_data(
-            data_container.eo,
+            data_container.expected_outputs,
             default_value=default_value_expected_outputs,
             batch_size=batch_size
-        ) if pad_eo else data_container.eo
+        ) if pad_eo else data_container.expected_outputs,
     )
 
     return data_container
 
 
-def _pad_data(data: Iterable, default_value: Any, batch_size: int):
+def _pad_data(data: DACTData, default_value: Any, batch_size: int):
+    if data is None:
+        return None
     data_ = []
     data_.extend(data)
     padding = copy.copy([default_value] * (batch_size - len(data)))

--- a/neuraxle/distributed/streaming.py
+++ b/neuraxle/distributed/streaming.py
@@ -677,6 +677,7 @@ class BaseQueuedPipeline(MiniBatchSequentialPipeline):
             step.start(context, logging_queue)
 
         # prepare minibatch iterator:
+        data_container.set_ids(data_container.ids)
         minibatch_iterator: Iterable[DACT[IDT, DIT, EOT]] = data_container.minibatches(
             batch_size=self.batch_size,
             keep_incomplete_batch=self.keep_incomplete_batch,

--- a/neuraxle/logging/logging.py
+++ b/neuraxle/logging/logging.py
@@ -58,6 +58,10 @@ class _FilterSTDErr(logging.Filter):
 class NeuraxleLogger(logging.Logger):
 
     @staticmethod
+    def root() -> 'NeuraxleLogger':
+        return NeuraxleLogger(NEURAXLE_LOGGER_NAME)
+
+    @staticmethod
     def from_identifier(identifier: str) -> 'NeuraxleLogger':
         """
         Returns a logger from an identifier.

--- a/neuraxle/metaopt/auto_ml.py
+++ b/neuraxle/metaopt/auto_ml.py
@@ -139,7 +139,7 @@ class Trainer(BaseService):
             eval_dact_train: DACT[IDT, ARG_Y_PREDICTD, ARG_Y_EXPECTED] = eval_dact_train
             _has_empty_eo = eval_dact_train.expected_outputs is None or (hasattr(
                 eval_dact_train.expected_outputs, "__len__") and len(eval_dact_train.expected_outputs) == 0)
-            if _has_empty_eo:
+            if _has_empty_eo or self.validation_splitter.force_fixed_metric_expected_outputs is True:
                 eval_dact_train = eval_dact_train.with_eo(train_dact.expected_outputs)
 
             if val_dact is not None:
@@ -151,7 +151,7 @@ class Trainer(BaseService):
                 eval_dact_valid: DACT[IDT, ARG_Y_PREDICTD, ARG_Y_EXPECTED] = eval_dact_valid
                 _has_empty_eo = eval_dact_valid.expected_outputs is None or (hasattr(
                     eval_dact_valid.expected_outputs, "__len__") and len(eval_dact_valid.expected_outputs) == 0)
-                if _has_empty_eo:
+                if _has_empty_eo or self.validation_splitter.force_fixed_metric_expected_outputs is True:
                     eval_dact_valid = eval_dact_valid.with_eo(val_dact.expected_outputs)
             else:
                 eval_dact_valid = None

--- a/neuraxle/metaopt/auto_ml.py
+++ b/neuraxle/metaopt/auto_ml.py
@@ -120,13 +120,13 @@ class Trainer(BaseService):
             eval_dact_train = p.handle_predict(
                 train_dact.without_eo(),
                 trial_split_scope.context.validation())
-            eval_dact_train: DACT[IDT, ARG_Y_PREDICTD, ARG_Y_EXPECTED] = eval_dact_train.with_eo(train_dact.eo)
+            eval_dact_train: DACT[IDT, ARG_Y_PREDICTD, ARG_Y_EXPECTED] = eval_dact_train.with_eo(train_dact.expected_outputs)
 
             if val_dact is not None:
                 eval_dact_valid = p.handle_predict(
                     val_dact.without_eo(),
                     trial_split_scope.context.validation())
-                eval_dact_valid: DACT[IDT, ARG_Y_PREDICTD, ARG_Y_EXPECTED] = eval_dact_valid.with_eo(val_dact.eo)
+                eval_dact_valid: DACT[IDT, ARG_Y_PREDICTD, ARG_Y_EXPECTED] = eval_dact_valid.with_eo(val_dact.expected_outputs)
             else:
                 eval_dact_valid = None
 

--- a/neuraxle/metaopt/context.py
+++ b/neuraxle/metaopt/context.py
@@ -49,19 +49,20 @@ class AutoMLContext(CX):
     def logger_at_scoped_loc(self) -> NeuraxleLogger:
         return logging.getLogger(self.get_identifier(include_step_names=False))
 
-    def add_scoped_logger_file_handler(self) -> NeuraxleLogger:
+    def add_scoped_logger_file_handler(self) -> 'AutoMLContext':
         """
         Add a file handler to the logger at the current scoped location to capture logs
         at this scope and below this scope.
         """
-
         self.repo.add_logging_handler(self.logger_at_scoped_loc, self.loc)
+        return self
 
-    def free_scoped_logger_file_handler(self):
+    def free_scoped_logger_file_handler(self) -> 'AutoMLContext':
         """
         Remove file handlers from logger to free file lock (especially on Windows).
         """
         self.logger_at_scoped_loc.without_file_handler()
+        return self
 
     def read_scoped_log(self) -> str:
         """

--- a/neuraxle/metaopt/context.py
+++ b/neuraxle/metaopt/context.py
@@ -30,7 +30,7 @@ that needs to be adapted in AutoML loops.
 
 import logging
 
-from neuraxle.base import ExecutionContext as CX
+from neuraxle.base import ExecutionContext as CX, ExecutionPhase
 from neuraxle.logging.logging import NeuraxleLogger
 from neuraxle.metaopt.data.vanilla import (BaseDataclass, ScopedLocation,
                                            SubDataclassT)
@@ -70,12 +70,44 @@ class AutoMLContext(CX):
         # TODO: with self.lock:
         return self.repo.get_log_from_logging_handler(self.logger, self.loc)
 
-    def _copy(self):
-        copy_kwargs = self._get_copy_kwargs()
+    def _copy(self, copy_func: str = '_copy'):
+        copy_kwargs = self._get_copy_kwargs(copy_func)
         return AutoMLContext(**copy_kwargs)
 
-    def _get_copy_kwargs(self):
-        return super()._get_copy_kwargs()
+    def _get_copy_kwargs(self, copy_func: str):
+        return CX._get_copy_kwargs(self, copy_func)
+
+    def new_trial(self) -> 'CX':
+        """
+        Set the context's execution phase to train.
+        """
+        new_self = self._copy(copy_func='_copy_trial')
+        new_self.set_execution_phase(ExecutionPhase.PRETRAIN)
+        return new_self
+
+    def new_trial_split(self) -> 'CX':
+        """
+        Set the context's execution phase to train.
+        """
+        new_self = self._copy(copy_func='_copy_trial_split')
+        new_self.set_execution_phase(ExecutionPhase.PRETRAIN)
+        return new_self
+
+    def train(self) -> 'CX':
+        """
+        Set the context's execution phase to train.
+        """
+        new_self = self._copy(copy_func='_copy_train')
+        new_self.set_execution_phase(ExecutionPhase.TRAIN)
+        return new_self
+
+    def validation(self) -> 'CX':
+        """
+        Set the context's execution phase to validation.
+        """
+        new_self = self._copy(copy_func='_copy_validation')
+        new_self.set_execution_phase(ExecutionPhase.VALIDATION)
+        return new_self
 
     @staticmethod
     def from_context(

--- a/neuraxle/metaopt/data/aggregates.py
+++ b/neuraxle/metaopt/data/aggregates.py
@@ -112,7 +112,7 @@ class BaseAggregate(BaseReport, _CouldHaveContext, BaseService, ContextManager[S
         self._dataclass: SubDataclassT = _dataclass
         self._spare: SubDataclassT = copy.copy(_dataclass).shallow()
         # TODO: pre-push context to allow for dc auto-loading and easier parent auto-loading?
-        self.context: AutoMLContext = context.push_attr(_dataclass)
+        self.context: AutoMLContext = context.push_attr(_dataclass).add_scoped_logger_file_handler()
         self.loc: ScopedLocation = self.context.loc._copy()
         self.is_deep = is_deep
         self._parent: ParentAggregateT = parent
@@ -293,9 +293,6 @@ class BaseAggregate(BaseReport, _CouldHaveContext, BaseService, ContextManager[S
         # self.context.free_scoped_logger_handler_file()
         self._invariant()
         self._managed_resource._invariant()
-        with self.repo.lock:  # TODO: locking twice, not needed.
-            self._managed_resource.context.add_scoped_logger_file_handler()
-
         return self._managed_resource
 
     def __exit__(
@@ -348,6 +345,7 @@ class BaseAggregate(BaseReport, _CouldHaveContext, BaseService, ContextManager[S
         with self.repo.lock:
             self.refresh(self.is_deep)
             self.save(False)  # TODO: is this bad?
+
         handled_error = e is None
         return handled_error
 

--- a/neuraxle/metaopt/data/aggregates.py
+++ b/neuraxle/metaopt/data/aggregates.py
@@ -559,7 +559,7 @@ class Round(RoundReport, BaseAggregate[Client, 'Trial', RoundReport, RoundDatacl
         else:
             self.flow.log_retraining(trial_id, _trial_dataclass.hyperparams)
 
-        subagg: Trial = Trial(_trial_dataclass, self.context, is_deep=True)
+        subagg: Trial = Trial(_trial_dataclass, self.context.new_trial(), is_deep=True)
         if continue_on_error:
             subagg.continue_loop_on_error()
         return subagg
@@ -687,7 +687,7 @@ class Trial(TrialReport, BaseAggregate[Round, 'TrialSplit', TrialReport, TrialDa
         _split_dataclass: TrialSplitDataclass = self.repo.load(split_loc)
         _split_dataclass.hyperparams = self.get_hyperparams()
 
-        subagg: TrialSplit = TrialSplit(_split_dataclass, self.context, is_deep=True)
+        subagg: TrialSplit = TrialSplit(_split_dataclass, self.context.new_trial_split(), is_deep=True)
         return subagg
 
     def _release_managed_subresource(self, resource: 'TrialSplit', e: Exception = None) -> bool:

--- a/neuraxle/metaopt/repositories/db.py
+++ b/neuraxle/metaopt/repositories/db.py
@@ -509,6 +509,8 @@ class _DatabaseLoggerHandlerMixin:
 
 class DatabaseHyperparamRepository(_DatabaseLoggerHandlerMixin, HyperparamsRepository):
     def __init__(self, engine, session):
+        HyperparamsRepository.__init__(self)
+        _DatabaseLoggerHandlerMixin.__init__(self)
         self.engine = engine
         self.session = session
 
@@ -553,7 +555,7 @@ class SQLLiteHyperparamsRepository(DatabaseHyperparamRepository):
         _Session.configure(bind=engine)
         session = _Session()
 
-        super().__init__(engine, session)
+        DatabaseHyperparamRepository.__init__(self, engine, session)
         self.create_db()
 
 

--- a/neuraxle/metaopt/repositories/json.py
+++ b/neuraxle/metaopt/repositories/json.py
@@ -58,12 +58,13 @@ class _OnDiskRepositoryLoggerHandlerMixin:
         Adds an on-disk logging handler to the repository.
         The file at this scope can be retrieved with the method :func:`get_scoped_logger_path`.
         """
-        logging_file = self.get_scoped_logger_path(scope)
-        os.makedirs(os.path.dirname(logging_file), exist_ok=True)
+        logging_file = self._create_scoped_logger_path(scope)
         logger.with_file_handler(logging_file)
         return self
 
     def get_log_from_logging_handler(self, logger: NeuraxleLogger, scope: ScopedLocation) -> str:
+        logging_file = self._create_scoped_logger_path(scope)
+        logger.with_file_handler(logging_file)
         return ''.join(logger.read_log_file())
 
     def get_folder_at_scope(self, scope: ScopedLocation) -> str:
@@ -71,9 +72,11 @@ class _OnDiskRepositoryLoggerHandlerMixin:
         _scope_attrs = [ON_DISK_DELIM + s for s in _scope_attrs]
         return os.path.join(self.cache_folder, *_scope_attrs)
 
-    def get_scoped_logger_path(self, scope: ScopedLocation) -> str:
+    def _create_scoped_logger_path(self, scope: ScopedLocation) -> str:
         scoped_path: str = self.get_folder_at_scope(scope)
-        return os.path.join(scoped_path, 'log.txt')
+        logging_file = os.path.join(scoped_path, 'log.txt')
+        os.makedirs(os.path.dirname(logging_file), exist_ok=True)
+        return logging_file
 
 
 class HyperparamsOnDiskRepository(_OnDiskRepositoryLoggerHandlerMixin, HyperparamsRepository):

--- a/neuraxle/steps/flow.py
+++ b/neuraxle/steps/flow.py
@@ -566,17 +566,17 @@ class SelectNonEmptyDataContainer(TransformHandlerOnlyMixin, BaseTransformer):
 
     def _transform_data_container(self, data_container: DACT, context: CX):
 
-        data_containers = list(filter(
-            lambda dc: (len(dc.di) > 0 and len(dc.eo) > 0),
+        filtered_data_containers = list(filter(
+            lambda dc: (len(dc.data_inputs) > 0 or len(dc.expected_outputs) > 0),
             data_container.data_inputs
         ))
-        if len(data_containers) == 1:
-            return data_containers[0]
+        if len(filtered_data_containers) == 1:
+            return filtered_data_containers[0]
         else:
             return DACT(
-                ids=data_container.ids,
-                di=list(map(attrgetter("di"))),
-                eo=list(map(attrgetter("eo"))),
+                ids=data_container._ids,
+                di=list(map(attrgetter("data_inputs"))),
+                eo=list(map(attrgetter("expected_outputs"))),
             )
 
 

--- a/neuraxle/steps/flow.py
+++ b/neuraxle/steps/flow.py
@@ -393,20 +393,20 @@ class ChooseOneStepOf(FeatureUnion):
         :class:`Optional`
     """
 
-    def __init__(self, steps, hyperparams=None):
+    def __init__(self, steps, default_choice=None):
         FeatureUnion.__init__(self, steps, joiner=SelectNonEmptyDataContainer())
 
         self._make_all_steps_optional()
 
         choices = list(self.keys())[:-1]
 
-        if hyperparams is None:
+        if default_choice is None:
             self.update_hyperparams({
                 ChooseOneStepOf.CHOICE_HYPERPARAM: choices[0]
             })
         else:
             self.update_hyperparams({
-                ChooseOneStepOf.CHOICE_HYPERPARAM: hyperparams
+                ChooseOneStepOf.CHOICE_HYPERPARAM: default_choice
             })
         self.update_hyperparams_space({
             ChooseOneStepOf.CHOICE_HYPERPARAM: Choice(choices)

--- a/neuraxle/steps/loop.py
+++ b/neuraxle/steps/loop.py
@@ -381,7 +381,7 @@ class FlattenForEach(ForceHandleMixin, MetaStep):
         :param list_to_flatten: list to flatten
         :return: flattened list, len flattened lists
         """
-        if _data is None:
+        if _data is None or all(v is None for v in _data):
             return None, []
 
         if len(_data) != 0:

--- a/neuraxle/steps/loop.py
+++ b/neuraxle/steps/loop.py
@@ -24,12 +24,11 @@ Pipeline Steps For Looping
 """
 import copy
 from operator import itemgetter
-from typing import Callable, List, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
-from neuraxle.base import (CX, DACT, BaseStep, BaseTransformer,
-                           ForceHandleMixin, ForceHandleOnlyMixin, Identity,
+from neuraxle.base import (CX, DACT, BaseStep, BaseTransformer, ForceHandleMixin, ForceHandleOnlyMixin, Identity,
                            MetaStep, NamedStepsList, TruncableJoblibStepSaver)
-from neuraxle.data_container import ListDataContainer
+from neuraxle.data_container import DACTData, ListDataContainer
 from neuraxle.steps.flow import ExecuteIf
 
 import numpy as np
@@ -315,9 +314,16 @@ class StepClonerForEachDataInput(ForceHandleOnlyMixin, MetaStep):
         return list(map(itemgetter(0), self.steps_as_tuple))
 
 
+lens = int  # Lengths of the dact data items that was pre-flattening
+
+
 class FlattenForEach(ForceHandleMixin, MetaStep):
     """
     Step that reduces a dimension instead of manually looping on it.
+
+    Using this step is equivalent to doing `sum(dact_data, [])` for each dact_data
+    that might be a IDT, DIT, or EOT of a DACT (DAtaConTainer) to flatten the data,
+    then the data is by default unflattened at the end of the loop in _did_process.
     """
 
     def __init__(
@@ -331,43 +337,36 @@ class FlattenForEach(ForceHandleMixin, MetaStep):
         self.then_unflatten = then_unflatten
 
         # Lengths temporarily stored in _will_process to be able to unflatten the data container in _did_process:
-        self.len_ids: List[int] = []
-        self.len_di: List[int] = []
-        self.len_eo: List[int] = []
+        self.len_ids: List[lens] = []
+        self.len_di: List[lens] = []
+        self.len_eo: List[lens] = []
 
     def _will_process(
         self, data_container: DACT, context: CX
     ) -> Tuple['BaseTransformer', DACT]:
         """
-        Flatten data container before any processing is done on the wrapped step.
-
-        :param data_container: data container to flatten
-        :param context: execution context
-        :return: (data container, execution context)
+        Flatten data container before any processing is done on the wrapped step, using lists.
         """
         data_container, context = super()._will_process(data_container, context)
 
-        if data_container.expected_outputs is None:
-            expected_outputs = np.empty_like(np.array(data_container.data_inputs))
-            expected_outputs.fill(np.nan)
-            data_container.set_expected_outputs(expected_outputs)
-
-        _id, self.len_ids = self._flatten_list(data_container.ids)
+        _ids, self.len_ids = self._flatten_list(data_container._ids)
         di, self.len_di = self._flatten_list(data_container.data_inputs)
         eo, self.len_eo = self._flatten_list(data_container.expected_outputs)
 
-        if len(di) != len(eo):
-            if all(v is None for v in eo):
-                eo = [None] * len(di)
-            else:
+        # Data consitency checks:
+        if di is not None:
+            if eo is not None and len(di) != len(eo):
+                if all(v is None for v in eo):
+                    eo = [None] * len(di)
+                else:
+                    raise ValueError(
+                        'FlattenForEach: Cannot flatten data properly. Expected outputs has a different len than data inputs.')
+            if _ids is not None and len(di) != len(_ids):
                 raise ValueError(
-                    'FlattenForEach: Cannot flatten data properly. Expected outputs has a different len than data inputs.')
-        if len(di) != len(eo):
-            raise ValueError(
-                'FlattenForEach: Cannot flatten data properly. IDs has a different len than data inputs.')
+                    'FlattenForEach: Cannot flatten data properly. IDs has a different len than data inputs.')
 
         flattened_data_container = DACT(
-            ids=_id,
+            ids=_ids,
             data_inputs=di,
             expected_outputs=eo,
             sub_data_containers=data_container.sub_data_containers
@@ -375,61 +374,58 @@ class FlattenForEach(ForceHandleMixin, MetaStep):
 
         return flattened_data_container, context
 
-    def _flatten_list(self, list_to_flatten):
+    def _flatten_list(self, _data: Union[Optional[DACTData], List[DACTData]]) -> Tuple[Optional[DACTData], List[lens]]:
         """
         Flatten the first dimension of a list.
 
         :param list_to_flatten: list to flatten
         :return: flattened list, len flattened lists
         """
+        if _data is None:
+            return None, []
 
-        if not isinstance(list_to_flatten, np.ndarray):
-            list_to_flatten = np.array(list_to_flatten)
+        if len(_data) != 0:
+            try:
+                iter(_data)
+            except TypeError:
+                return _data, [1 for x in _data]
 
-        if len(list_to_flatten.shape) == 1:
-            return list_to_flatten, [1 for x in list_to_flatten]
-
-        list_to_flatten = list(list_to_flatten)
-        list_to_flatten = [list(x) for x in list_to_flatten]
-        len_list_to_flatten = [len(x) for x in list_to_flatten]
-        flattened_list = sum(list_to_flatten, [])
+        _data = [list(x) for x in _data]
+        len_list_to_flatten = [len(x) for x in _data]
+        flattened_list = sum(_data, [])
 
         return flattened_list, len_list_to_flatten
 
     def _did_process(self, data_container: DACT, context: CX) -> DACT:
         """
-        Reaugment the flattened data container.
-
-        :param data_container: data container to then_unflatten
-        :param context: execution context
-        :return: data container
+        Reaugment the flattened data container back to its full original shape using lists.
         """
         data_container = super()._did_process(data_container, context)
 
         if self.then_unflatten:
-            data_container.set_ids(self._reaugment_list(data_container.ids, self.len_ids))
-            data_container.set_data_inputs(self._reaugment_list(data_container.data_inputs, self.len_di))
-            data_container.set_expected_outputs(self._reaugment_list(data_container.expected_outputs, self.len_eo))
+            if data_container._ids is not None:
+                data_container.set_ids(self._reaugment_list(data_container.ids, self.len_ids))
+            if data_container.data_inputs is not None:
+                data_container.set_data_inputs(self._reaugment_list(data_container.data_inputs, self.len_di))
+            if data_container.expected_outputs is not None:
+                data_container.set_expected_outputs(self._reaugment_list(data_container.expected_outputs, self.len_eo))
             self.len_ids = []
             self.len_di = []
             self.len_eo = []
 
         return data_container
 
-    def _reaugment_list(self, list_to_reaugment, flattened_dimension_lengths):
+    def _reaugment_list(self, _data: DACTData, flattened_dims_lengths: List[lens]) -> List[DACTData]:
         """
         Reaugment list with the flattened dimension lengths.
-
-        :param list_to_reaugment: list to then_unflatten
-        :return: reaugmented numpy array
         """
-        if not self.then_unflatten or list_to_reaugment is None:
-            return list_to_reaugment
+        if not self.then_unflatten or _data is None:
+            return _data
 
-        reaugmented_list = []
+        reaugmented_list: List[DACTData] = []
         i = 0
-        for list_length in flattened_dimension_lengths:
-            sub_list = list_to_reaugment[i:i + list_length]
+        for list_length in flattened_dims_lengths:
+            sub_list: DACTData = _data[i:i + list_length]
             reaugmented_list.append(sub_list)
             i += list_length
 

--- a/neuraxle/steps/loop.py
+++ b/neuraxle/steps/loop.py
@@ -318,17 +318,6 @@ class StepClonerForEachDataInput(ForceHandleOnlyMixin, MetaStep):
 class FlattenForEach(ForceHandleMixin, MetaStep):
     """
     Step that reduces a dimension instead of manually looping on it.
-
-    .. seealso::
-        :class:`~neuraxle.base.BaseStep`,
-        :class:`~neuraxle.base.BaseSaver`,
-        :class:`~neuraxle.base.BaseHasher`,
-        :class:`~neuraxle.base.MetaStepMixin`,
-        :class:`~neuraxle.base.NonTransformableMixin`,
-        :class:`~neuraxle.pipeline.Pipeline`,
-        :class:`~neuraxle.hyperparams.space.HyperparameterSamples`,
-        :class:`~neuraxle.hyperparams.space.HyperparameterSpace`,
-        :class:`~neuraxle.data_container.DataContainer`
     """
 
     def __init__(

--- a/neuraxle/steps/loop.py
+++ b/neuraxle/steps/loop.py
@@ -360,10 +360,12 @@ class FlattenForEach(ForceHandleMixin, MetaStep):
                     eo = [None] * len(di)
                 else:
                     raise ValueError(
-                        'FlattenForEach: Cannot flatten data properly. Expected outputs has a different len than data inputs.')
+                        f"FlattenForEach: Cannot flatten data properly. Expected outputs has a different len than data "
+                        f"inputs for DACT: {data_container}.")
             if _ids is not None and len(di) != len(_ids):
                 raise ValueError(
-                    'FlattenForEach: Cannot flatten data properly. IDs has a different len than data inputs.')
+                    f"FlattenForEach: Cannot flatten data properly. IDs has a different len than data inputs "
+                    f"for DACT: {data_container}.")
 
         flattened_data_container = DACT(
             ids=_ids,

--- a/neuraxle/steps/misc.py
+++ b/neuraxle/steps/misc.py
@@ -26,13 +26,13 @@ You can find here misc. pipeline steps, for example, callbacks useful for debugg
 
 import random
 import time
-from abc import ABC
-from typing import Any, Callable, List, Optional, Tuple
 import uuid
+from abc import ABC
+from typing import Any, Callable, List, Optional, Tuple, Union
 
-from neuraxle.base import BaseStep, BaseTransformer, NonFittableMixin
+from neuraxle.base import BaseStep, BaseTransformer
 from neuraxle.base import ExecutionContext as CX
-from neuraxle.base import ForceHandleOnlyMixin, HandleOnlyMixin, MetaStep
+from neuraxle.base import ForceHandleOnlyMixin, HandleOnlyMixin, MetaStep, NonFittableMixin
 from neuraxle.data_container import DataContainer as DACT
 from neuraxle.hyperparams.space import RecursiveDict
 
@@ -213,8 +213,8 @@ class FitTransformCallbackStep(BaseStep):
 
 class CallbackWrapper(HandleOnlyMixin, MetaStep):
     """
-    A step that calls a callback function for each of his methods : transform, fit, fit_transform, and even inverse_transform.
-    To be used with :class:`TapeCallbackFunction`.
+    A step that calls a callback function for each of his methods: transform, fit, fit_transform, and even inverse_transform.
+    To be used with :class:`TapeCallbackFunction` most of the time, passed in the constructor.
 
     .. code-block:: python
 
@@ -233,9 +233,9 @@ class CallbackWrapper(HandleOnlyMixin, MetaStep):
     def __init__(
             self,
             wrapped,
-            transform_callback_function,
-            fit_callback_function,
-            inverse_transform_callback_function=None,
+            transform_callback_function: Union['TapeCallbackFunction', Callable],
+            fit_callback_function: Union['TapeCallbackFunction', Callable],
+            inverse_transform_callback_function: Union['TapeCallbackFunction', Callable] = None,
             more_arguments: List = tuple(),
             hyperparams=None
     ):

--- a/neuraxle/steps/misc.py
+++ b/neuraxle/steps/misc.py
@@ -33,6 +33,7 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 from neuraxle.base import BaseStep, BaseTransformer
 from neuraxle.base import ExecutionContext as CX
 from neuraxle.base import ForceHandleOnlyMixin, HandleOnlyMixin, MetaStep, NonFittableMixin
+from neuraxle.data_container import DIT, EOT
 from neuraxle.data_container import DataContainer as DACT
 from neuraxle.hyperparams.space import RecursiveDict
 
@@ -332,13 +333,13 @@ class TapeCallbackFunction:
 
     def __init__(self):
         """Initialize the tape (cache lists)."""
-        self.data: List = []
+        self.data: List[Union[DIT, Tuple[DIT, EOT]]] = []  # at each time the callback is called, data is appened.
         self.name_tape: List[str] = []
 
     def __call__(self, *args, **kwargs):
         return self.callback(*args, **kwargs)
 
-    def callback(self, data, name: str = ""):
+    def callback(self, data: Tuple[DIT, EOT], name: str = ""):
         """
         Will stick the data and name to the tape.
 

--- a/testing_neuraxle/hyperparams/test_scipy_distributions.py
+++ b/testing_neuraxle/hyperparams/test_scipy_distributions.py
@@ -6,13 +6,11 @@ import joblib
 import numpy as np
 import pytest
 from neuraxle.base import Identity
-from neuraxle.hyperparams.distributions import (Choice, LogNormal, LogUniform,
-                                                Normal, PriorityChoice,
-                                                RandInt, Uniform,
+from neuraxle.hyperparams.distributions import (Choice, LogNormal, LogUniform, Normal, PriorityChoice, RandInt, Uniform,
                                                 get_index_in_list_with_bool)
-from neuraxle.hyperparams.scipy_distributions import (
-    Gaussian, Histogram, Poisson, ScipyContinuousDistributionWrapper,
-    ScipyDiscreteDistributionWrapper, ScipyLogUniform, StdMeanLogNormal)
+from neuraxle.hyperparams.scipy_distributions import (Gaussian, Histogram, Poisson, ScipyContinuousDistributionWrapper,
+                                                      ScipyDiscreteDistributionWrapper, ScipyLogUniform,
+                                                      StdMeanLogNormal)
 from neuraxle.hyperparams.space import HyperparameterSpace
 from scipy.stats import gamma, norm, randint, uniform
 
@@ -26,10 +24,10 @@ def get_many_samples_for(hd):
 def test_wrapped_sk_learn_distributions_should_be_able_to_use_sklearn_methods():
     wrapped_sklearn_distribution = Gaussian(min_included=0, max_included=10, null_default_value=0)
 
-    assert wrapped_sklearn_distribution.logpdf(5) == -13.418938533204672
-    assert wrapped_sklearn_distribution.logcdf(5) == -0.6931477538632531
-    assert wrapped_sklearn_distribution.sf(5) == 0.5000002866515718
-    assert wrapped_sklearn_distribution.logsf(5) == -0.693146607256966
+    assert np.isclose(wrapped_sklearn_distribution.logpdf(5), -13.418938533204672)
+    assert np.isclose(wrapped_sklearn_distribution.logcdf(5), -0.6931477538632531)
+    assert np.isclose(wrapped_sklearn_distribution.sf(5), 0.5000002866515718)
+    assert np.isclose(wrapped_sklearn_distribution.logsf(5), -0.693146607256966)
     assert np.all(wrapped_sklearn_distribution.ppf([0.0, 0.01, 0.05, 0.1, 1 - 0.10, 1 - 0.05, 1 - 0.01, 1.0], 10))
     assert 8 < wrapped_sklearn_distribution.isf(q=0.5) > 8
     assert wrapped_sklearn_distribution.moment(2) > 50
@@ -38,10 +36,10 @@ def test_wrapped_sk_learn_distributions_should_be_able_to_use_sklearn_methods():
     assert stats[1]
     assert np.array_equal(wrapped_sklearn_distribution.entropy(), np.array(0.7094692666023363))
     assert wrapped_sklearn_distribution.median()
-    assert wrapped_sklearn_distribution.mean() == 5.398942280397029
+    assert np.isclose(wrapped_sklearn_distribution.mean(), 5.398942280397029)
     assert np.isclose(wrapped_sklearn_distribution.std(), 4.620759921685375)
     assert np.isclose(wrapped_sklearn_distribution.var(), 21.351422253853833)
-    assert wrapped_sklearn_distribution.expect() == 0.39894228040143276
+    assert np.isclose(wrapped_sklearn_distribution.expect(), 0.39894228040143276)
     interval = wrapped_sklearn_distribution.interval(alpha=[0.25, 0.50])
     assert np.all(interval[0])
     assert np.all(interval[1])
@@ -103,10 +101,10 @@ def _test_discrete_poisson(poisson_distribution: Poisson):
     rvs = [poisson_distribution.rvs() for i in range(10)]
     assert not all(x == rvs[0] for x in rvs)
     assert 0.0 <= poisson_distribution.rvs() <= 10.0
-    assert poisson_distribution.pdf(10) == 0.01813278870782187
+    assert np.isclose(poisson_distribution.pdf(10), 0.01813278870782187)
     assert np.isclose(poisson_distribution.pdf(0), 0.006737946999085467)
-    assert poisson_distribution.cdf(5.0) == 0.6159606548330632
-    assert poisson_distribution.cdf(0) == 0.006737946999085467
+    assert np.isclose(poisson_distribution.cdf(5.0), 0.6159606548330632)
+    assert np.isclose(poisson_distribution.cdf(0), 0.006737946999085467)
 
 
 def test_randint():
@@ -172,7 +170,7 @@ def _test_loguniform(hd: ScipyLogUniform):
     assert min(samples) >= 0.001
     assert max(samples) <= 10.0
     assert hd.pdf(0.0001) == 0.
-    assert abs(hd.pdf(2) - 0.054286810237906484) < 2e-6
+    assert np.isclose(hd.pdf(2), 0.054286810237906484)
     assert hd.pdf(10.1) == 0.
     assert hd.cdf(0.0001) == 0.
     assert abs(hd.cdf(2) - (math.log2(2) - math.log2(0.001)) / (math.log2(10) - math.log2(0.001))) < 1e-6
@@ -197,12 +195,12 @@ def _test_normal(hd):
     assert 0.6 > samples_mean > 0.4
     samples_std = np.std(samples)
     assert 0.1 < samples_std < 0.6
-    assert (abs(hd.pdf(-1.) - 0.24) - 0.24) < 1e-10
-    assert (abs(hd.pdf(0.) - 0.40) - 0.31125636093539194) < 1e-10
-    assert (abs(hd.pdf(1.)) - 0.08874363906460808) < 1e-10
-    assert (abs(hd.cdf(-1.) - 0.15) - 0.15) < 1e-10
-    assert (abs(hd.cdf(+0.) - 0.5) - 0.5) < 1e-10
-    assert (abs(hd.cdf(+1.) - 0.85) - 0.15000000000000002) < 1e-10
+    assert np.isclose(abs(hd.pdf(-1.) - 0.24), 0.24)
+    assert np.isclose(abs(hd.pdf(0.) - 0.40), 0.31125636093539194)
+    assert np.isclose(abs(hd.pdf(1.)), 0.08874363906460808)
+    assert np.isclose(abs(hd.cdf(-1.) - 0.15), 0.15)
+    assert np.isclose(abs(hd.cdf(+0.) - 0.5), 0.5)
+    assert np.isclose(abs(hd.cdf(+1.) - 0.85), 0.15000000000000002)
 
 
 def test_lognormal():
@@ -223,12 +221,12 @@ def _test_lognormal(hd: StdMeanLogNormal):
     assert -5 < samples_median < 5
     samples_std = np.std(samples)
     assert 0 < samples_std < 4
-    assert hd.pdf(0.) == 0.
-    assert abs(hd.pdf(1.) - 0.28777602476804065) < 1e-6
-    assert abs(hd.pdf(5.) - 0.029336304593386688) < 1e-6
-    assert hd.cdf(0.) == 0.
-    assert hd.cdf(1.) == 0.49999999998280026
-    assert abs(hd.cdf(5.) - 0.8771717397015799) == 0.12282826029842009
+    assert np.isclose(hd.pdf(0.), 0.)
+    assert np.isclose(hd.pdf(1.), 0.28777602476804065)
+    assert np.isclose(hd.pdf(5.), 0.029336304593386688)
+    assert np.isclose(hd.cdf(0.), 0.)
+    assert np.isclose(hd.cdf(1.), 0.49999999998280026)
+    assert np.isclose(abs(hd.cdf(5.) - 0.8771717397015799), 0.12282826029842009)
 
 
 @pytest.mark.parametrize("hd, test_method", [

--- a/testing_neuraxle/metaopt/test_automl_redesign.py
+++ b/testing_neuraxle/metaopt/test_automl_redesign.py
@@ -3,13 +3,12 @@ from typing import Callable, Optional
 
 import numpy as np
 import pytest
+from neuraxle.base import BaseStep, NonFittableMixin
 from neuraxle.data_container import DataContainer as DACT
-from neuraxle.hyperparams.distributions import (Boolean, Choice, LogUniform,
-                                                RandInt)
+from neuraxle.hyperparams.distributions import Boolean, Choice, LogUniform, RandInt
 from neuraxle.hyperparams.space import HyperparameterSpace
 from neuraxle.metaopt.auto_ml import AutoML, RandomSearchSampler
-from neuraxle.metaopt.callbacks import (EarlyStoppingCallback, MetricCallback,
-                                        ScoringCallback)
+from neuraxle.metaopt.callbacks import EarlyStoppingCallback, MetricCallback, ScoringCallback
 from neuraxle.metaopt.context import AutoMLContext
 from neuraxle.metaopt.repositories.repo import VanillaHyperparamsRepository
 from neuraxle.metaopt.validation import ValidationSplitter
@@ -20,14 +19,24 @@ from neuraxle.steps.sklearn import SKLearnWrapper
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, mean_squared_error
 from sklearn.preprocessing import StandardScaler
-from testing_neuraxle.metaopt.test_automl_repositories import (
-    CX_WITH_REPO_CTORS, TmpDir)
+from testing_neuraxle.metaopt.test_automl_repositories import CX_WITH_REPO_CTORS, TmpDir
 
 
 def _create_data_source():
     data_inputs = np.random.random((25, 50)).astype(np.float32)
     expected_outputs = (np.random.random((25,)) > 0.5).astype(np.int32)
     return data_inputs, expected_outputs
+
+
+class SetNoneEO(NonFittableMixin, BaseStep):
+
+    def __init__(self):
+        BaseStep.__init__(self)
+        NonFittableMixin.__init__(self)
+
+    def _will_process(self, dact, cx):
+        cx = cx.with_eo(None)
+        return dact, cx
 
 
 def _create_pipeline():
@@ -42,7 +51,8 @@ def _create_pipeline():
                 'penalty': Choice(['none', 'l2']),
                 'max_iter': RandInt(20, 200)
             })
-        )
+        ),
+        SetNoneEO(),
     ])
 
 

--- a/testing_neuraxle/steps/test_expand_dim.py
+++ b/testing_neuraxle/steps/test_expand_dim.py
@@ -10,33 +10,28 @@ from neuraxle.steps.misc import HandleCallbackStep, TapeCallbackFunction
 
 def test_expand_dim_transform():
     di = np.array(range(10))
-    eo = [None] * 10
-    handle_fit_callback = TapeCallbackFunction()
-    handle_transform_callback = TapeCallbackFunction()
-    handle_fit_transform_callback = TapeCallbackFunction()
+    eo = None
+    fit_callback, transform_callback, fit_transform_callback = (
+        TapeCallbackFunction(), TapeCallbackFunction(), TapeCallbackFunction())
     p = Pipeline([
         ExpandDim(
-            HandleCallbackStep(
-                handle_fit_callback,
-                handle_transform_callback,
-                handle_fit_transform_callback
-            )
+            HandleCallbackStep(fit_callback, transform_callback, fit_transform_callback)
         )
     ])
 
     outputs = p.transform(di)
 
     assert np.array_equal(outputs, di)
-    assert handle_fit_callback.data == []
+    assert fit_callback.data == []
     assert np.array_equal(
-        np.array(handle_transform_callback.data[0][0].di),
+        np.array(transform_callback.data[0][0].di),
         np.array([di])
     )
     assert np.array_equal(
-        np.array(handle_transform_callback.data[0][0].eo),
+        np.array(transform_callback.data[0][0].eo),
         np.array([eo])
     )
-    assert handle_fit_transform_callback.data == []
+    assert fit_transform_callback.data == []
 
 
 def test_expand_dim_fit():

--- a/testing_neuraxle/steps/test_output_transformer_wrapper.py
+++ b/testing_neuraxle/steps/test_output_transformer_wrapper.py
@@ -3,14 +3,12 @@ from typing import Any, Tuple
 from neuraxle.base import BaseTransformer
 from neuraxle.base import ExecutionContext as CX
 from neuraxle.data_container import DataContainer as DACT
-from neuraxle.hyperparams.space import (HyperparameterSamples,
-                                        HyperparameterSpace)
+from neuraxle.hyperparams.space import HyperparameterSamples, HyperparameterSpace
 from neuraxle.pipeline import Pipeline
-from neuraxle.steps.output_handlers import InputAndOutputTransformerMixin
-from py._path.local import LocalPath
+from neuraxle.steps.output_handlers import IdsAndInputAndOutputTransformerMixin
 
 
-class MultiplyBy2OutputTransformer(InputAndOutputTransformerMixin, BaseTransformer):
+class MultiplyBy2OutputTransformer(IdsAndInputAndOutputTransformerMixin, BaseTransformer):
     def __init__(
             self,
             hyperparams: HyperparameterSamples = None,
@@ -18,10 +16,10 @@ class MultiplyBy2OutputTransformer(InputAndOutputTransformerMixin, BaseTransform
             name: str = None
     ):
         BaseTransformer.__init__(self, hyperparams, hyperparams_space, name)
-        InputAndOutputTransformerMixin.__init__(self)
+        IdsAndInputAndOutputTransformerMixin.__init__(self)
 
     def transform(self, data_inputs) -> Tuple[Any, Any]:
-        dis, eos = data_inputs
+        ids, dis, eos = data_inputs
 
         new_dis = []
         new_eos = []
@@ -29,17 +27,17 @@ class MultiplyBy2OutputTransformer(InputAndOutputTransformerMixin, BaseTransform
             new_dis.append(di * 2)
             new_eos.append(eo * 2)
 
-        return new_dis, new_eos
+        return ids, new_dis, new_eos
 
 
-def test_output_transformer_should_zip_data_input_and_expected_output_in_the_transformed_output(tmpdir: LocalPath):
+def test_output_transformer_should_zip_data_input_and_expected_output_in_the_transformed_output():
     pipeline = Pipeline([
         MultiplyBy2OutputTransformer()
     ])
 
     pipeline, new_data_container = pipeline.handle_fit_transform(
         DACT(data_inputs=[1, 2, 3], ids=[0, 1, 2], expected_outputs=[2, 3, 4]),
-        CX(tmpdir)
+        CX()
     )
 
     assert new_data_container.data_inputs == [2, 4, 6]

--- a/testing_neuraxle/steps/test_sklearn_wrapper.py
+++ b/testing_neuraxle/steps/test_sklearn_wrapper.py
@@ -120,8 +120,6 @@ def _create_data_source(shape):
     return data_inputs, expected_outputs
 
 
-# With AutoML loop
-
 def _test_within_auto_ml_loop(tmpdir, pipeline):
     X_train = np.random.random((25, 50)).astype(np.float32)
     Y_train = np.random.random((25,)).astype(np.float32)
@@ -144,13 +142,11 @@ def _test_within_auto_ml_loop(tmpdir, pipeline):
     auto_ml.fit(X_train, Y_train)
 
 
-@pytest.mark.skip(reason="AutoML loop refactor")
 def test_automl_sklearn(tmpdir):
     grad_boost = SKLearnWrapper(GradientBoostingRegressor())
     _test_within_auto_ml_loop(tmpdir, grad_boost)
 
 
-@pytest.mark.skip(reason="AutoML loop refactor")
 def test_automl_sklearn_model_with_base_estimator(tmpdir):
     grad_boost = GradientBoostingRegressor()
     bagged_regressor = BaggingRegressor(
@@ -159,7 +155,7 @@ def test_automl_sklearn_model_with_base_estimator(tmpdir):
     wrapped_bagged_regressor = SKLearnWrapper(
         bagged_regressor,
         HyperparameterSpace({
-            "n_estimators": RandInt(10, 100),
+            "n_estimators": RandInt(2, 15),
             "max_features": Uniform(0.6, 1.0)}),
         #  return_all_sklearn_default_params_on_get=True
     )

--- a/testing_neuraxle/test_context_logger.py
+++ b/testing_neuraxle/test_context_logger.py
@@ -164,7 +164,8 @@ def test_automl_neuraxle_logger_logs_to_repo_file(tmpdir):
         tsc.flow.log_status(TrialStatus.RUNNING)
         tsc.flow.log_end(TrialStatus.ABORTED)
 
-        log_file_path_at_loc = cx.repo.wrapped.get_scoped_logger_path(tsc.loc)
+        _repo: HyperparamsOnDiskRepository = cx.repo.wrapped
+        log_file_path_at_loc = _repo._create_scoped_logger_path(tsc.loc)
         assert os.path.exists(log_file_path_at_loc)
         log1 = tsc.context.read_scoped_log()
         with open(log_file_path_at_loc, 'r') as _file:

--- a/testing_neuraxle/test_context_logger.py
+++ b/testing_neuraxle/test_context_logger.py
@@ -276,30 +276,31 @@ class SomeParallelLogginWorkers:
     def start(self):
         for i in range(self.n_process):
             proc = Process(
-                target=self.logger_producer_thread,
+                target=logger_producer_thread,
                 name=f"worker_{i}",
                 args=(self.logging_queue,)
             )
             self.workers.append(proc)
             proc.start()
 
-    @staticmethod
-    def logger_producer_thread(logging_queue: Queue):
-        queue_handler = logging.handlers.QueueHandler(logging_queue)
-        root = logging.getLogger()
-        root.setLevel(logging.DEBUG)
-        root.addHandler(queue_handler)
-
-        logger = CX().logger
-        logger.log(logging.ERROR, SomeParallelLogginWorkers.FIRST_LOG_MESSAGE)
-
-        dact = DACT(di=range(10))
-        _, out = FitTransformCounterLoggingStep().set_name("Producer").handle_fit_transform(dact, CX())
-        return
-
     def join(self):
         for worker in self.workers:
             worker.join()
+
+
+def logger_producer_thread(logging_queue: Queue):
+    # TODO: isn't this duplicated from the logging module or streaming.py code?
+    queue_handler = logging.handlers.QueueHandler(logging_queue)
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    root.addHandler(queue_handler)
+
+    logger = CX().logger
+    logger.log(logging.ERROR, SomeParallelLogginWorkers.FIRST_LOG_MESSAGE)
+
+    dact = DACT(di=range(10))
+    _, out = FitTransformCounterLoggingStep().set_name("Producer").handle_fit_transform(dact, CX())
+    return
 
 
 def test_neuraxle_logger_can_operate_in_parallel():

--- a/testing_neuraxle/test_full_pipeline_dump.py
+++ b/testing_neuraxle/test_full_pipeline_dump.py
@@ -30,7 +30,7 @@ def test_load_full_dump_from_pipeline_name(tmpdir):
     step_b_wrapped_step = pipeline.wrapped['step_b'].wrapped
     assert np.array_equal(step_b_wrapped_step.transform_callback_function.data[0], EXPECTED_OUTPUTS)
     assert np.array_equal(step_b_wrapped_step.fit_callback_function.data[0][0], EXPECTED_OUTPUTS)
-    assert np.array_equal(step_b_wrapped_step.fit_callback_function.data[0][1], [None] * len(EXPECTED_OUTPUTS))
+    assert np.array_equal(step_b_wrapped_step.fit_callback_function.data[0][1], None)
 
     pipeline.save(CX(tmpdir), full_dump=True)
 
@@ -44,7 +44,7 @@ def test_load_full_dump_from_pipeline_name(tmpdir):
     loaded_step_b_wrapped_step = loaded_pipeline['step_b'].wrapped
     assert np.array_equal(loaded_step_b_wrapped_step.transform_callback_function.data[0], EXPECTED_OUTPUTS)
     assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][0], EXPECTED_OUTPUTS)
-    assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][1], [None] * len(EXPECTED_OUTPUTS))
+    assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][1], None)
 
 
 def test_load_full_dump_from_path(tmpdir):
@@ -69,4 +69,4 @@ def test_load_full_dump_from_path(tmpdir):
     loaded_step_b_wrapped_step = loaded_pipeline.wrapped
     assert np.array_equal(loaded_step_b_wrapped_step.transform_callback_function.data[0], EXPECTED_OUTPUTS)
     assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][0], EXPECTED_OUTPUTS)
-    assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][1], [None] * len(EXPECTED_OUTPUTS))
+    assert np.array_equal(loaded_step_b_wrapped_step.fit_callback_function.data[0][1], None)

--- a/testing_neuraxle/test_output_transformer_wrapper.py
+++ b/testing_neuraxle/test_output_transformer_wrapper.py
@@ -1,14 +1,13 @@
 import numpy as np
 import pytest
-
 from neuraxle.base import CX, BaseTransformer, ForceHandleMixin
+from neuraxle.data_container import EOT
 from neuraxle.data_container import DataContainer as DACT
 from neuraxle.hyperparams.space import HyperparameterSamples
 from neuraxle.pipeline import Pipeline
 from neuraxle.steps.misc import FitCallbackStep, TapeCallbackFunction
 from neuraxle.steps.numpy import MultiplyByN
-from neuraxle.steps.output_handlers import OutputTransformerWrapper, InputAndOutputTransformerWrapper, \
-    InputAndOutputTransformerMixin
+from neuraxle.steps.output_handlers import InputAndOutputTransformerWrapper, OutputTransformerWrapper
 
 
 class MultiplyByNInputAndOutput(BaseTransformer):
@@ -47,7 +46,8 @@ def test_output_transformer_wrapper_should_fit_with_data_inputs_and_expected_out
 
     assert np.array_equal(tape.data[0][0], expected_outputs)
     for i in range(10):
-        assert tape.data[0][1][i] is None
+        _first_eot_seen: EOT = tape.data[0][1]
+        assert _first_eot_seen is None
 
 
 def test_output_transformer_wrapper_should_fit_transform_with_data_inputs_and_expected_outputs():
@@ -64,7 +64,8 @@ def test_output_transformer_wrapper_should_fit_transform_with_data_inputs_and_ex
     assert np.array_equal(data_container.expected_outputs, expected_outputs * 2)
     assert np.array_equal(tape.data[0][0], expected_outputs * 2)
     for i in range(10):
-        assert tape.data[0][1][i] is None
+        _first_eot_seen: EOT = tape.data[0][1]
+        assert _first_eot_seen is None
 
 
 def test_output_transformer_wrapper_should_transform_with_data_inputs_and_expected_outputs():

--- a/testing_neuraxle/test_output_transformer_wrapper.py
+++ b/testing_neuraxle/test_output_transformer_wrapper.py
@@ -1,13 +1,15 @@
 import numpy as np
 import pytest
-from neuraxle.base import CX, BaseTransformer, ForceHandleMixin
+from neuraxle.base import BaseTransformer
+from neuraxle.base import ExecutionContext as CX
+from neuraxle.base import ForceHandleMixin
 from neuraxle.data_container import EOT
 from neuraxle.data_container import DataContainer as DACT
 from neuraxle.hyperparams.space import HyperparameterSamples
 from neuraxle.pipeline import Pipeline
 from neuraxle.steps.misc import FitCallbackStep, TapeCallbackFunction
 from neuraxle.steps.numpy import MultiplyByN
-from neuraxle.steps.output_handlers import InputAndOutputTransformerWrapper, OutputTransformerWrapper
+from neuraxle.steps.output_handlers import IdsInputAndOutputTransformerWrapper, OutputTransformerWrapper
 
 
 class MultiplyByNInputAndOutput(BaseTransformer):
@@ -15,7 +17,7 @@ class MultiplyByNInputAndOutput(BaseTransformer):
         super().__init__(hyperparams=HyperparameterSamples({'multiply_by': multiply_by}))
 
     def transform(self, data_inputs):
-        data_inputs, expected_outputs = data_inputs
+        ids, data_inputs, expected_outputs = data_inputs
 
         if not isinstance(data_inputs, np.ndarray):
             data_inputs = np.array(data_inputs)
@@ -23,10 +25,10 @@ class MultiplyByNInputAndOutput(BaseTransformer):
         if not isinstance(expected_outputs, np.ndarray):
             expected_outputs = np.array(expected_outputs)
 
-        return data_inputs * self.hyperparams['multiply_by'], expected_outputs * self.hyperparams['multiply_by']
+        return ids, data_inputs * self.hyperparams['multiply_by'], expected_outputs * self.hyperparams['multiply_by']
 
     def inverse_transform(self, processed_outputs):
-        processed_outputs, expected_outputs = processed_outputs
+        ids, processed_outputs, expected_outputs = processed_outputs
 
         if not isinstance(processed_outputs, np.ndarray):
             processed_outputs = np.array(processed_outputs)
@@ -34,7 +36,7 @@ class MultiplyByNInputAndOutput(BaseTransformer):
         if not isinstance(expected_outputs, np.ndarray):
             expected_outputs = np.array(expected_outputs)
 
-        return processed_outputs / self.hyperparams['multiply_by'], expected_outputs / self.hyperparams['multiply_by']
+        return ids, processed_outputs / self.hyperparams['multiply_by'], expected_outputs / self.hyperparams['multiply_by']
 
 
 def test_output_transformer_wrapper_should_fit_with_data_inputs_and_expected_outputs_as_data_inputs():
@@ -83,33 +85,36 @@ def test_output_transformer_wrapper_should_transform_with_data_inputs_and_expect
 
 def test_input_and_output_transformer_wrapper_should_fit_with_data_inputs_and_expected_outputs_as_data_inputs():
     tape = TapeCallbackFunction()
-    p = InputAndOutputTransformerWrapper(FitCallbackStep(tape))
-    data_inputs, expected_outputs = _create_data_source((10, 10))
+    p = IdsInputAndOutputTransformerWrapper(FitCallbackStep(tape))
+    ids, data_inputs, expected_outputs = _create_data_source((10, 10), with_ids=True)
 
-    p.fit(data_inputs, expected_outputs)
+    p.handle_fit(DACT(ids=ids, di=data_inputs, eo=expected_outputs), CX())
 
-    assert np.array_equal(tape.data[0][0][0], data_inputs)
-    assert np.array_equal(tape.data[0][0][1], expected_outputs)
+    assert np.array_equal(tape.data[0][0][0], ids)
+    assert np.array_equal(tape.data[0][0][1], data_inputs)
+    assert np.array_equal(tape.data[0][0][2], expected_outputs)
 
 
 def test_input_and_output_transformer_wrapper_should_fit_transform_with_data_inputs_and_expected_outputs():
     tape = TapeCallbackFunction()
-    p = InputAndOutputTransformerWrapper(Pipeline([MultiplyByNInputAndOutput(2), FitCallbackStep(tape)]))
-    data_inputs, expected_outputs = _create_data_source((10, 10))
+    p = IdsInputAndOutputTransformerWrapper(Pipeline([MultiplyByNInputAndOutput(2), FitCallbackStep(tape)]))
+    ids, data_inputs, expected_outputs = _create_data_source((10, 10), with_ids=True)
 
     p, data_container = p.handle_fit_transform(DACT(
+        ids=ids,
         data_inputs=data_inputs,
         expected_outputs=expected_outputs
     ), CX())
 
     assert np.array_equal(data_container.data_inputs, data_inputs * 2)
     assert np.array_equal(data_container.expected_outputs, expected_outputs * 2)
-    assert np.array_equal(tape.data[0][0][0], data_inputs * 2)
-    assert np.array_equal(tape.data[0][0][1], expected_outputs * 2)
+    assert np.array_equal(tape.data[0][0][0], ids)
+    assert np.array_equal(tape.data[0][0][1], data_inputs * 2)
+    assert np.array_equal(tape.data[0][0][2], expected_outputs * 2)
 
 
 def test_input_and_output_transformer_wrapper_should_transform_with_data_inputs_and_expected_outputs():
-    p = InputAndOutputTransformerWrapper(MultiplyByNInputAndOutput(2))
+    p = IdsInputAndOutputTransformerWrapper(MultiplyByNInputAndOutput(2))
     data_inputs, expected_outputs = _create_data_source((10, 10))
 
     data_container = p.handle_transform(DACT(
@@ -130,11 +135,11 @@ class ChangeLenDataInputs(BaseTransformer):
         super().__init__()
 
     def transform(self, data_inputs):
-        data_inputs, expected_outputs = data_inputs
-        return data_inputs[0:int(len(data_inputs) / 2)], expected_outputs
+        ids, data_inputs, expected_outputs = data_inputs
+        return ids, data_inputs[0:int(len(data_inputs) / 2)], expected_outputs
 
 
-class ChangeLenDataInputsAndExpectedOutputs(BaseTransformer):
+class ChangeLenDataInputsAndExpectedOutputsWithoutIds(BaseTransformer):
     """
     This should raise an error because ids are not changed to fit the new length of data_inputs and expected_outputs
     """
@@ -143,8 +148,9 @@ class ChangeLenDataInputsAndExpectedOutputs(BaseTransformer):
         BaseTransformer.__init__(self)
 
     def transform(self, data_inputs):
-        data_inputs, expected_outputs = data_inputs
-        return data_inputs[0:int(len(data_inputs) / 2)], expected_outputs[0:int(len(data_inputs) / 2)]
+        ids, data_inputs, expected_outputs = data_inputs
+        _clip = int(len(data_inputs) / 2)
+        return ids, data_inputs[:_clip], expected_outputs[:_clip]
 
 
 class DoubleData(ForceHandleMixin, BaseTransformer):
@@ -157,49 +163,61 @@ class DoubleData(ForceHandleMixin, BaseTransformer):
         ForceHandleMixin.__init__(self)
 
     def _transform_data_container(self, data_container: DACT, context: CX) -> DACT:
-        di, eo = data_container.data_inputs
-        return DACT(data_inputs=(di[0].tolist()*2, eo[0].tolist()*2),
-                             ids=data_container.ids*2)
+        ids, di, eo = data_container.data_inputs
+        return DACT(
+            data_inputs=(
+                ids * 2 if ids is not None else None,
+                di[0].tolist() * 2,
+                eo[0].tolist() * 2),
+            ids=list(data_container.ids)
+        )
 
 
 def test_input_and_output_transformer_wrapper_should_not_return_a_different_amount_of_data_inputs_and_expected_outputs():
     with pytest.raises(AssertionError):
-        p = InputAndOutputTransformerWrapper(ChangeLenDataInputs())
-        data_inputs, expected_outputs = _create_data_source((10, 10))
+        p = IdsInputAndOutputTransformerWrapper(ChangeLenDataInputs())
+        ids, data_inputs, expected_outputs = _create_data_source((10, 10), with_ids=True)
 
         p.handle_transform(DACT(
+            ids=ids,
             data_inputs=data_inputs,
             expected_outputs=expected_outputs
         ), CX())
 
 
 def test_input_and_output_transformer_wrapper_should_raise_an_assertion_error_if_ids_have_not_been_resampled_correctly():
-    with pytest.raises(AssertionError) as e:
-        p = InputAndOutputTransformerWrapper(ChangeLenDataInputsAndExpectedOutputs())
-        data_inputs, expected_outputs = _create_data_source((10, 10))
+    with pytest.raises(AssertionError):
+        p = IdsInputAndOutputTransformerWrapper(ChangeLenDataInputsAndExpectedOutputsWithoutIds())
+        ids, data_inputs, expected_outputs = _create_data_source((10, 10), with_ids=True)
 
         p.handle_transform(DACT(
+            ids=ids,
             data_inputs=data_inputs,
             expected_outputs=expected_outputs
         ), CX())
 
 
 def test_data_doubler():
-    p = InputAndOutputTransformerWrapper(DoubleData())
-    data_inputs, expected_outputs = _create_data_source((10, 10))
+    p = IdsInputAndOutputTransformerWrapper(DoubleData())
+    ids, data_inputs, expected_outputs = _create_data_source((10, 10), with_ids=True)
 
     out = p.handle_transform(DACT(
+        ids=ids,
         data_inputs=data_inputs,
         expected_outputs=expected_outputs
     ), CX())
 
     doubled_length = len(out.data_inputs)
-    assert doubled_length == 2*len(data_inputs)
+    assert doubled_length == 2 * len(data_inputs)
     assert doubled_length == len(out.expected_outputs)
     assert doubled_length == len(out.ids)
 
 
-def _create_data_source(shape):
+def _create_data_source(shape, with_ids=False):
     data_inputs = np.random.random(shape).astype(np.float32)
     expected_outputs = np.random.random(shape).astype(np.float32)
-    return data_inputs, expected_outputs
+    if with_ids:
+        ids = list(range(len(data_inputs)))
+        return ids, data_inputs, expected_outputs
+    else:
+        return data_inputs, expected_outputs


### PR DESCRIPTION
General improvements and bugfixes:

- Update FlattenForEach that wasn't up to date
- Use _ids, data_inputs, and expected_outputs more often in DataContainer instead of shorthand ids, di, and eo, which were auto-filling values too often when looping over things in flow classes and output handlers
- Changed InputAndOutputTransformerMixin to IdsAndInputAndOutputTransformerMixin and derived classes to also process IDs more often in triplets rather than duo tuples of di and eo. 
- Fixed bugs in DataContainer
- Easy to read string representation of the DataContainer (DACT) is now possible for easier print debugging at a glimpse
- Repair some skipped tests
- Cleaned some docstrings
- Add str and repr functionalities to context to show its services and parents in detail upon printing.
- _TruncableMixin that is common to _TruncableSteps and _TruncableService
- Introducing _TruncableServiceWithBodyMixin for .body and .joiner that is easier. Also fix FlattenForEach.
- Added different copy constructors to services depending on the AutoML train/val phase

__________________


## Checklist before merging PR.

Things to check each time you contribute:
<!-- Note: you may delete this list from your PR's description -->

- [x] If this is your first contribution to Neuraxle, please read the [guide to contributing to the Neuraxle framework](https://www.neuraxle.org/stable/Neuraxle/CONTRIBUTING.html).
- [x] Your local Git username is set to your GitHub username, and your local Git email is set to your GitHub email. This is important to avoid breaking the cla-bot and for your contributions to be linked to your profile. More info: https://github.com/settings/emails
- [x] Argument's dimensions and types are specified for new steps (important), with examples in docstrings when needed.
- [x] Class names and argument / API variables are very clear: there is no possible ambiguity. They also respect the existing code style (avoid duplicating words for the same concept) and are intuitive.
- [x] Use typing like `variable: Typing = ...` as much as possible. Also use typing for function arguments and return values like `def my_func(self, my_list: Dict[int, List[str]]) -> 'OrderedDict[int, str]':`.
- [x] Classes are documented: their behavior is explained beyond just the title of the class. You may even use the description written in your pull request above to fill some docstrings accurately.
- [x] If a numpy array is used, it is important to remember that these arrays are a special type that must be documented accordingly, and that numpy array should not be abused. This is because Neuraxle is a library that is not only limited to transforming numpy arrays. To this effect, numpy steps should probably be located in the existing numpy python files as much as possible, and not be all over the place. The same applies to Pandas DataFrames.
- [x] Code coverage is above 90% for the added code for the unit tests.
- [x] The above description of the pull request in natural language was used to document the new code inside the code's docstrings so as to have complete documentation, with examples.
- [x] Respect the Unit Testing status check
- [x] Respect the Codacy status check
- [x] Respect the cla-bot status check (unless the cla-bot is truly broken - please try to debug it first)
- [x] Code files that were edited were reformatted automatically using PyCharm's `Ctrl+Alt+L` shortcut. You may have reorganized imports as well.
